### PR TITLE
Fix: Correct critical runtime errors from previous submission.

### DIFF
--- a/pages/select_patient_for_form.php
+++ b/pages/select_patient_for_form.php
@@ -57,8 +57,13 @@ if (isset($_SESSION['user_id'])) {
         </div>
     <?php endif; ?>
 
-    <?php if (empty($db_error_message) && !empty($clinician_patients)) : ?>
-        <table class="table table-striped table-hover table-bordered"> <!-- Ensured consistency and added table-hover -->
+    <?php if (!empty($db_error_message)): ?>
+        <?php // The main database error is already displayed further up. ?>
+        <?php // This block can be used if there's specific content to show when the patient list can't be displayed due to the error. ?>
+        <?php // For now, we can omit an additional message here if the main error message is sufficient, or add a simple one. ?>
+        <div class="alert alert-warning mt-3">Could not display the patient list due to an issue (see message above if applicable).</div>
+    <?php elseif (!empty($clinician_patients)) : ?>
+        <table class="table table-striped table-hover table-bordered">
             <thead>
                 <tr>
                     <th>Patient ID</th>
@@ -82,15 +87,9 @@ if (isset($_SESSION['user_id'])) {
                 <?php endforeach; ?>
             </tbody>
         </table>
-    <?php else : ?>
+    <?php else : // This case means $db_error_message is empty AND $clinician_patients is empty ?>
         <div class="alert alert-info">
-            You have no patients assigned to you for whom forms can be filled.
-            If a patient has been recently assigned, they should appear here.
-            Contact administration if you believe this is an error or if issues persist.
-        </div>
-    <?php elseif (empty($db_error_message) && empty($clinician_patients)) : ?>
-        <div class="alert alert-info">
-            No patients are currently assigned to you.
+            No patients are currently assigned to you. If a patient has been recently assigned, they should appear here. You can also add new patients via your dashboard.
         </div>
     <?php endif; ?>
 

--- a/pages/view_my_patients.php
+++ b/pages/view_my_patients.php
@@ -12,7 +12,9 @@ if (!isset($_SESSION["user_id"]) || $_SESSION["role"] !== 'clinician') {
     exit;
 }
 
-require_once $path_to_root . 'includes/db_connect.php'; // $mysqli connection object
+// $path_to_root = "../"; // This is still needed for header.php to build its internal paths for CSS, JS, and navigation.
+// The require_once paths below will use __DIR__ for robustness of file inclusion itself.
+require_once __DIR__ . '/../includes/db_connect.php'; // $mysqli connection object
 
 $my_patients = [];
 $db_error_message = '';
@@ -40,7 +42,8 @@ if ($stmt === false) {
 // $mysqli->close(); // Connection usually closed at end of script by PHP or db_connect.php
 
 $page_title = "My Assigned Patients";
-require_once $path_to_root . 'includes/header.php'; 
+// $path_to_root must be defined before including header.php for its internal use.
+require_once __DIR__ . '/../includes/header.php'; 
 // header.php includes navigation.php, which handles displaying $_SESSION['message'] (global messages)
 ?>
     <?php // The main content div class="container" is provided by header.php for the <main> element ?>
@@ -88,4 +91,4 @@ require_once $path_to_root . 'includes/header.php';
         </div>
     <?php endif; ?>
 
-<?php require_once $path_to_root . 'includes/footer.php'; ?>
+<?php require_once __DIR__ . '/../includes/footer.php'; ?>


### PR DESCRIPTION
This commit addresses two critical errors reported after the last deployment:
1.  A fatal error in `pages/view_my_patients.php` due to a failure to open `../includes/db_connect.php`. This was fixed by changing the `require_once` statements in this file to use the more robust `__DIR__ . '/../includes/...'` path construction method for including `db_connect.php`, `header.php`, and `footer.php`. The `$path_to_root = "../";` variable is still defined for use by `header.php` for its internal asset and navigation links.

2.  A parse error (syntax error, unexpected token "elseif") in `pages/select_patient_for_form.php`. This was caused by an `elseif` condition appearing after an `else` block. The conditional logic for displaying the patient list or relevant messages in this file has been restructured to correct the syntax and improve clarity.

A quick review of other files in the `pages/` directory did not reveal similar widespread path issues for includes, suggesting the problem in `view_my_patients.php` might have been isolated or due to a previous file update anomaly.