### PR TITLE
Fix: Recreate missing db_connect.php and db_config.php

### DIFF
--- a/includes/db_config.php
+++ b/includes/db_config.php
@@ -1,0 +1,18 @@
+<?php
+
+// Database Configuration Settings
+// Replace these placeholder values with your actual database credentials.
+
+// Database Host (e.g., 'localhost' or '127.0.0.1')
+define('DB_HOST', 'localhost');
+
+// Database Username
+define('DB_USER', 'your_db_user');
+
+// Database Password
+define('DB_PASSWORD', 'your_db_password');
+
+// Database Name
+define('DB_NAME', 'your_db_name');
+
+?>

--- a/includes/db_connect.php
+++ b/includes/db_connect.php
@@ -1,0 +1,36 @@
+<?php
+
+// Centralized Database Connection
+
+// Require the database configuration file once.
+// Using __DIR__ to ensure path is correct regardless of where this file is included from,
+// though for includes/db_config.php it's a sibling.
+require_once __DIR__ . '/db_config.php';
+
+// Attempt to connect to MySQL database
+$mysqli = new mysqli(DB_HOST, DB_USER, DB_PASSWORD, DB_NAME);
+
+// Check connection
+if ($mysqli->connect_error) {
+    // Log the detailed error to the server's error log
+    error_log("Database Connection Failed: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error);
+    
+    // For AJAX requests or APIs, it's often better to output a JSON error.
+    // For general pages, a user-friendly HTML message might be better,
+    // but since this can be included anywhere, JSON is a safer default for die().
+    // If this script's failure leads to a broken page, the JSON might not be seen directly by user,
+    // but it avoids breaking JSON responses for scripts that expect them.
+    header('Content-Type: application/json'); // Ensure header is set for JSON output
+    die(json_encode([
+        'status' => 'error',
+        'message' => 'Database connection error. Please check server logs or contact administrator.'
+    ]));
+}
+
+// Set charset to utf8mb4 for broader character support (optional but recommended)
+if (!$mysqli->set_charset("utf8mb4")) {
+    error_log("Error loading character set utf8mb4: " . $mysqli->error);
+    // Continue execution even if charset setting fails, but log it.
+}
+
+?>


### PR DESCRIPTION
This commit addresses a fatal error ("Failed to open stream") caused by the absence of `includes/db_connect.php` and its dependency `includes/db_config.php`.

These files have been re-created in the `includes/` directory:
- `db_config.php`: Contains placeholder constants for database credentials.
- `db_connect.php`: Establishes the MySQLi database connection using credentials from `db_config.php`.

Additionally, I re-verified that `pages/view_my_patients.php` uses the robust `__DIR__ . '/../includes/...'` path construction for its PHP `require_once` statements, while also ensuring `$path_to_root` is correctly defined for use by `header.php` for its internal asset and navigation links.

These changes should resolve the file inclusion errors and restore database connectivity to the application.