### PR TITLE
Refactor patient and form workflows

### DIFF
--- a/pages/fill_patient_form.php
+++ b/pages/fill_patient_form.php
@@ -88,6 +88,28 @@ if ($stmt_patient_name) {
     exit();
 }
 
+// Check if the requested form is a clinical evaluation form and if general info is filled
+if ($form_directory_from_url === 'patient_evaluation_form') {
+    $check_stmt = $mysqli->prepare("SELECT COUNT(*) as count FROM patient_form_submissions WHERE patient_id = ? AND form_name = 'general-information.html' AND form_directory = 'patient_general_info'");
+    if (!$check_stmt) {
+        error_log("MySQLi prepare error (check general info form): " . $mysqli->error);
+        $_SESSION['message'] = "Error checking for general information form. Please try again.";
+        header("Location: dashboard.php"); // Or $select_patient_page
+        exit();
+    }
+    $check_stmt->bind_param("i", $selected_patient_id);
+    $check_stmt->execute();
+    $result = $check_stmt->get_result();
+    $row = $result->fetch_assoc();
+    $check_stmt->close();
+
+    if ($row['count'] == 0) {
+        $_SESSION['message'] = "Please fill out the General Information form for this patient before accessing clinical evaluations.";
+        // Redirect to the general-information.html form
+        header("Location: fill_patient_form.php?form_name=general-information.html&form_directory=patient_general_info&patient_id=" . urlencode($selected_patient_id));
+        exit();
+    }
+}
 
 // 6. Set page title
 $form_display_name = ucwords(str_replace(['_', '-'], ' ', pathinfo($form_file_basename, PATHINFO_FILENAME)));

--- a/patient_evaluation_form/general_assesment_form.html
+++ b/patient_evaluation_form/general_assesment_form.html
@@ -76,116 +76,16 @@
         </div>
 
         <div class="mb-2">
-            <label for="GA_B4_MedDiagnosis" class="form-label">Medical Diagnosis:</label>
-            <input type="text" id="GA_B4_MedDiagnosis" name="GA_B4_MedDiagnosis" class="form-control form-control-sm" placeholder="B4 details...">
-        </div>
-
-        <div class="mb-2">
             <label for="GA_B5_TreatingClinician" class="form-label">Treating Clinician:</label>
             <input type="text" id="GA_B5_TreatingClinician" name="GA_B5_TreatingClinician" class="form-control form-control-sm" placeholder="B5 details...">
         </div>
-
-        <div class="mb-2">
-            <label for="GA_B19_ChiefComplaint" class="form-label">Chief Complaint:</label>
-            <input type="text" id="GA_B19_ChiefComplaint" name="GA_B19_ChiefComplaint" class="form-control form-control-sm" placeholder="B19 details...">
-        </div>
-
-        <div class="mb-2">
-            <label for="GA_B6_PainScale" class="form-label">Pain Scale (1-10):</label>
-            <select id="GA_B6_PainScale" name="GA_B6_PainScale" class="form-select form-select-sm">
-                <option value="" selected disabled hidden>Select</option>
-                <option value="1">1</option><option value="2">2</option><option value="3">3</option>
-                <option value="4">4</option><option value="5">5</option><option value="6">6</option>
-                <option value="7">7</option><option value="8">8</option><option value="9">9</option>
-                <option value="10">10</option>
-            </select>
-        </div>
-
-        <div class="mb-2">
-            <label for="GA_B7_HPI" class="form-label">HPI:</label>
-            <input type="text" id="GA_B7_HPI" name="GA_B7_HPI" class="form-control form-control-sm" placeholder="B7 details...">
-        </div>
-
-        <div class="mb-2">
-            <label for="GA_B8_Allergies" class="form-label">Allergies:</label>
-            <input type="text" id="GA_B8_Allergies" name="GA_B8_Allergies" class="form-control form-control-sm" placeholder="B8 details...">
-        </div>
         
         <p class="fw-bold mb-1">Vital Sign</p>
-        <div class="mb-2">
-            <label for="GA_B9_Temperature" class="form-label">Temperature (B9):</label>
-            <input type="number" id="GA_B9_Temperature" name="GA_B9_Temperature" class="form-control form-control-sm" step="0.1" placeholder="e.g., 36.5">
-        </div>
-
-        <div class="mb-2">
-            <label for="GA_B13_BP_Systolic" class="form-label">BP (SID) (B13/B14):</label>
-            <div class="row g-2 align-items-center">
-                <div class="col">
-                    <input type="number" id="GA_B13_BP_Systolic" name="GA_B13_BP_Systolic" class="form-control form-control-sm" placeholder="Systolic">
-                </div>
-                <div class="col-auto px-0 text-center" style="width: 1em;">/</div>
-                <div class="col">
-                    <input type="number" id="GA_B14_BP_Diastolic" name="GA_B14_BP_Diastolic" class="form-control form-control-sm" placeholder="Diastolic">
-                </div>
-                <div class="col-auto ps-1">mmHg</div>
-            </div>
-        </div>
-
-        <div class="mb-2">
-            <label for="GA_B10_PulseRate" class="form-label">Pulse rate (B10):</label>
-            <input type="number" id="GA_B10_PulseRate" name="GA_B10_PulseRate" class="form-control form-control-sm" placeholder="e.g., 70">
-        </div>
-
-        <div class="mb-2">
-            <label for="GA_B15_RespiratoryRate" class="form-label">Respiratory Rate (B15):</label>
-            <div class="input-group input-group-sm">
-                <input type="number" id="GA_B15_RespiratoryRate" name="GA_B15_RespiratoryRate" class="form-control" placeholder="e.g., 16">
-                <span class="input-group-text">Per/min</span>
-            </div>
-        </div>
-
-        <div class="mb-2">
-            <label for="GA_B11_SPO2" class="form-label">SPO2 (B11):</label>
-            <div class="input-group input-group-sm">
-                <input type="number" id="GA_B11_SPO2" name="GA_B11_SPO2" class="form-control" placeholder="e.g., 98">
-                <span class="input-group-text">%</span>
-            </div>
-        </div>
-
-        <div class="mb-2">
-            <label for="GA_B16_Height" class="form-label">Height (B16):</label>
-            <div class="input-group input-group-sm">
-                <input type="number" id="GA_B16_Height" name="GA_B16_Height" class="form-control" step="0.1" placeholder="e.g., 175">
-                <span class="input-group-text">cm</span>
-            </div>
-        </div>
-
-        <div class="mb-2">
-            <label for="GA_B12_RBS" class="form-label">RBS (B12):</label>
-            <input type="number" id="GA_B12_RBS" name="GA_B12_RBS" class="form-control form-control-sm" placeholder="e.g., 90">
-        </div>
-
-        <div class="mb-2">
-            <label for="GA_B17_Weight" class="form-label">Weight (B17):</label>
-            <div class="input-group input-group-sm">
-                <input type="number" id="GA_B17_Weight" name="GA_B17_Weight" class="form-control" step="0.1" placeholder="e.g., 70.5">
-                <span class="input-group-text">kg</span>
-            </div>
-        </div>
         
-        <div class="mb-2">
-            <label for="GA_B18_Note" class="form-label">Note (B18):</label>
-            <input type="text" id="GA_B18_Note" name="GA_B18_Note" class="form-control form-control-sm" placeholder="B18 details...">
-        </div>
     </fieldset>
 
     <fieldset class="mt-4">
         <legend>Additional Assessment Details</legend>
-
-        <div class="mb-2">
-            <label for="GA2_B1_PastMedical" class="form-label">Past Medical and Surgical Illness (B1):</label>
-            <input type="text" id="GA2_B1_PastMedical" name="GA2_B1_PastMedical" class="form-control form-control-sm" placeholder="B1 details...">
-        </div>
 
         <p class="fw-bold mb-1">Physical Examination</p>
         <div class="mb-2">

--- a/patient_evaluation_form/pediatric_assesment.html
+++ b/patient_evaluation_form/pediatric_assesment.html
@@ -121,106 +121,17 @@
         </div>
 
         <div class="mb-2">
-            <label for="PA_P1_B4_MedDiagnosis" class="form-label">Medical Diagnosis:</label>
-            <input type="text" id="PA_P1_B4_MedDiagnosis" name="PA_P1_B4_MedDiagnosis" class="form-control form-control-sm" placeholder="B4 details...">
-        </div>
-
-        <div class="mb-2">
             <label for="PA_P1_B5_TreatingClinician" class="form-label">Treating Clinician:</label>
             <input type="text" id="PA_P1_B5_TreatingClinician" name="PA_P1_B5_TreatingClinician" class="form-control form-control-sm" placeholder="B5 details...">
         </div>
 
-        <div class="mb-2">
-            <label for="PA_P1_B6_ChiefComplaint" class="form-label">Chief Complaint:</label>
-            <input type="text" id="PA_P1_B6_ChiefComplaint" name="PA_P1_B6_ChiefComplaint" class="form-control form-control-sm" placeholder="B6 details...">
-        </div>
-
-        <div class="mb-2">
-            <label for="PA_P1_B7_HPI" class="form-label">HPI:</label>
-            <input type="text" id="PA_P1_B7_HPI" name="PA_P1_B7_HPI" class="form-control form-control-sm" placeholder="B7 details...">
-        </div>
-
-        <div class="mb-2">
-            <label for="PA_P1_B8_Allergies" class="form-label">Allergies:</label>
-            <input type="text" id="PA_P1_B8_Allergies" name="PA_P1_B8_Allergies" class="form-control form-control-sm" placeholder="B8 details...">
-        </div>
-
         <p class="fw-bold mb-1">Vital Sign</p>
-        <div class="mb-2">
-            <label for="PA_P1_B9_Temperature" class="form-label">Temperature (B9):</label>
-            <input type="number" id="PA_P1_B9_Temperature" name="PA_P1_B9_Temperature" class="form-control form-control-sm" step="0.1" placeholder="e.g., 36.5">
-        </div>
-
-        <div class="mb-2">
-            <label for="PA_P1_B13_BP_Systolic" class="form-label">BP (S/D) (B13/B14):</label>
-            <div class="row g-2 align-items-center">
-                <div class="col">
-                    <input type="number" id="PA_P1_B13_BP_Systolic" name="PA_P1_B13_BP_Systolic" class="form-control form-control-sm" placeholder="Systolic">
-                </div>
-                <div class="col-auto px-0 text-center" style="width: 1em;">/</div>
-                <div class="col">
-                    <input type="number" id="PA_P1_B14_BP_Diastolic" name="PA_P1_B14_BP_Diastolic" class="form-control form-control-sm" placeholder="Diastolic">
-                </div>
-                <div class="col-auto ps-1">mmHg</div>
-            </div>
-        </div>
-
-        <div class="mb-2">
-            <label for="PA_P1_B10_PulseRate" class="form-label">Pulse rate (B10):</label>
-            <input type="number" id="PA_P1_B10_PulseRate" name="PA_P1_B10_PulseRate" class="form-control form-control-sm" placeholder="e.g., 100">
-        </div>
-
-        <div class="mb-2">
-            <label for="PA_P1_B15_RespiratoryRate" class="form-label">Respiratory Rate (B15):</label>
-            <div class="input-group input-group-sm">
-                <input type="number" id="PA_P1_B15_RespiratoryRate" name="PA_P1_B15_RespiratoryRate" class="form-control" placeholder="e.g., 20">
-                <span class="input-group-text">breath per minute</span>
-            </div>
-        </div>
-
-        <div class="mb-2">
-            <label for="PA_P1_B11_SPO2" class="form-label">SPO2 (B11):</label>
-            <div class="input-group input-group-sm">
-                <input type="number" id="PA_P1_B11_SPO2" name="PA_P1_B11_SPO2" class="form-control" placeholder="e.g., 99">
-                <span class="input-group-text">%</span>
-            </div>
-        </div>
-
-        <div class="mb-2">
-            <label for="PA_P1_B16_Height" class="form-label">Height (B16):</label>
-            <div class="input-group input-group-sm">
-                <input type="number" id="PA_P1_B16_Height" name="PA_P1_B16_Height" class="form-control" step="0.1" placeholder="e.g., 100">
-                <span class="input-group-text">cm</span>
-            </div>
-        </div>
-
-        <div class="mb-2">
-            <label for="PA_P1_B12_RBS" class="form-label">RBS (B12):</label>
-            <input type="number" id="PA_P1_B12_RBS" name="PA_P1_B12_RBS" class="form-control form-control-sm" placeholder="e.g., 85">
-        </div>
-
-        <div class="mb-2">
-            <label for="PA_P1_B17_Weight" class="form-label">Weight (B17):</label>
-            <div class="input-group input-group-sm">
-                <input type="number" id="PA_P1_B17_Weight" name="PA_P1_B17_Weight" class="form-control" step="0.1" placeholder="e.g., 15.5">
-                <span class="input-group-text">kg</span>
-            </div>
-        </div>
         
-        <div class="mb-2">
-            <label for="PA_P1_B18_Note" class="form-label">Note (B18):</label>
-            <input type="text" id="PA_P1_B18_Note" name="PA_P1_B18_Note" class="form-control form-control-sm" placeholder="B18 details...">
-        </div>
     </fieldset>
 
     <fieldset class="mt-4">
         <legend>Medical History & Examination</legend>
 
-        <div class="mb-2">
-            <label for="PA_P2_B1_PastMedical" class="form-label">Past medical and Surgical Illness (B1):</label>
-            <input type="text" id="PA_P2_B1_PastMedical" name="PA_P2_B1_PastMedical" class="form-control form-control-sm" placeholder="B1 details...">
-        </div>
-        
         <p class="fw-bold mb-1">Physical Examination</p>
         <div class="mb-2">
             <label for="PA_P2_B2_PhysExamOverall" class="form-label">Overall Physical Examination (B2):</label>

--- a/patient_general_info/demo.html
+++ b/patient_general_info/demo.html
@@ -88,11 +88,13 @@
     </fieldset>
 
     <div class="mt-3">
-        <button type="button" class="btn btn-success" onclick="submitDemographicsForm()">Submit</button>
-        <button type="button" class="btn btn-danger" onclick="resetDemographicsForm()">Reset</button>
+        <button type="submit" class="btn btn-success">Submit</button>
+        <button type="reset" class="btn btn-danger">Reset</button>
     </div>
+    <div id="form-messages" class="mt-3"></div>
 </form>
 
+<script src="../../js/form_handler.js"></script>
 <script>
     // Collapsible fieldset script
     document.querySelectorAll("fieldset").forEach((fieldset) => {
@@ -117,41 +119,17 @@
         });
     });
 
-    // Placeholder form handling functions
-    function validateDemographicsForm() {
-        var form = document.getElementById("demographyForm");
-        if (!form) return false;
-        if (!form.checkValidity()) {
-            // Find the first invalid field and focus it for better UX
-            let firstInvalidField = form.querySelector(':invalid');
-            if (firstInvalidField) {
-                firstInvalidField.focus();
-            }
-            alert("Please fill out all required fields.");
-            return false;
+    document.addEventListener('DOMContentLoaded', function() {
+        // Ensure form_handler.js is loaded and initFormSubmissionHandler is available
+        if (typeof initFormSubmissionHandler === 'function') {
+            initFormSubmissionHandler('demographyForm', 'form-messages');
+        } else {
+            console.error('form_handler.js not loaded or initFormSubmissionHandler not defined.');
+            // Optionally display an error message in the form-messages div
+            var msgDiv = document.getElementById('form-messages');
+            if(msgDiv) msgDiv.innerHTML = '<div class="alert alert-danger">Error initializing form. Please contact support.</div>';
         }
-        return true;
-    }
-
-    function submitDemographicsForm() {
-        if (validateDemographicsForm()) {
-            alert("Demographics form submitted successfully!");
-            // Actual form submission logic (e.g., AJAX) would go here.
-            // const formData = new FormData(document.getElementById("demographyForm"));
-            // fetch('/your-submit-url', { method: 'POST', body: formData })
-            //   .then(response => response.json())
-            //   .then(data => console.log(data))
-            //   .catch(error => console.error('Error:', error));
-        }
-    }
-
-    function resetDemographicsForm() {
-        var form = document.getElementById("demographyForm");
-        if (form) {
-            form.reset();
-        }
-        // If there were any custom display elements to reset (like pain scale), do it here.
-    }
+    });
 </script>
 
 </body>

--- a/php/handle_add_patient.php
+++ b/php/handle_add_patient.php
@@ -87,8 +87,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
     // Execute the statement
     if ($stmt->execute()) {
-        $_SESSION['message'] = "Patient '" . htmlspecialchars($first_name) . " " . htmlspecialchars($last_name) . "' added successfully and saved to the database.";
-        header("Location: ../pages/dashboard.php");
+        $_SESSION['selected_patient_id_for_form'] = $stmt->insert_id; // Store new patient ID
+        $_SESSION['message'] = "Patient '" . htmlspecialchars($first_name) . " " . htmlspecialchars($last_name) . "' added successfully. Please fill out the demography form.";
+        header("Location: ../pages/fill_patient_form.php?form_name=demo.html&form_directory=patient_general_info"); // Redirect to demo form
     } else {
         error_log("MySQLi execute error (insert patient): " . $stmt->error);
         $_SESSION['message'] = "Error saving patient data: " . htmlspecialchars($stmt->error);

--- a/php/handle_submit_patient_form.php
+++ b/php/handle_submit_patient_form.php
@@ -124,8 +124,22 @@ $stmt_insert_submission->bind_param("issis", $patient_db_data['id'], $original_f
 if ($stmt_insert_submission->execute()) {
     $form_name_without_ext = pathinfo($form_basename, PATHINFO_FILENAME);
     $patient_display_name = htmlspecialchars($patient_db_data['first_name'] . ' ' . $patient_db_data['last_name']);
-    $_SESSION['message'] = "Form '" . htmlspecialchars($form_name_without_ext) . "' (from " . htmlspecialchars($form_directory) . ") submitted successfully for patient " . $patient_display_name . " and saved to the database.";
-    header("Location: ../pages/dashboard.php");
+
+    // Conditional redirect based on the form submitted
+    if ($original_form_name === 'demo.html' && $form_directory === 'patient_general_info') {
+        // $patient_id_post is available and validated
+        $_SESSION['message'] = "Demographics form submitted successfully. Please complete the general information form.";
+        // Assuming fill_patient_form.php uses patient_id from the session if not in GET,
+        // or that selected_patient_id_for_form is still set correctly.
+        // To be safe, let's ensure patient_id is passed if needed by fill_patient_form.php for the next form.
+        // The current selected_patient_id_for_form is the one we want.
+        header("Location: ../pages/fill_patient_form.php?form_name=general-information.html&form_directory=patient_general_info&patient_id=" . urlencode($patient_id_post));
+    } else {
+        // Existing redirect for other forms
+        $_SESSION['message'] = "Form '" . htmlspecialchars($form_name_without_ext) . "' submitted successfully for patient " . $patient_display_name . ".";
+        header("Location: ../pages/dashboard.php");
+    }
+    // exit; is called after this block, so it's fine.
 } else {
     error_log("MySQLi execute error (insert submission): " . $stmt_insert_submission->error);
     $_SESSION['message'] = "Error saving form submission to the database: " . htmlspecialchars($stmt_insert_submission->error);


### PR DESCRIPTION
This commit implements the following changes:

1.  Ensures that a 'demo.html' form is filled immediately after a new patient is created.
    - `php/handle_add_patient.php` now redirects to the demo form.
    - `patient_general_info/demo.html` has been updated to use the standard `form_handler.js`.

2.  Ensures that a 'general-information.html' form is filled immediately after the 'demo.html' form is submitted.
    - `php/handle_submit_patient_form.php` now redirects to the general information form after demo form submission.

3.  Enforces that 'general-information.html' must be completed for a patient before any clinical evaluation forms (from `patient_evaluation_form/`) can be accessed.
    - `pages/fill_patient_form.php` checks for the general information form submission and redirects if it's missing.

4.  Removes redundant fields from clinical evaluation forms that are already covered in 'general-information.html'.
    - Affected forms: `patient_evaluation_form/general_assesment_form.html` and `patient_evaluation_form/pediatric_assesment.html`.
    - Redundant fields such as general medical diagnosis, HPI, allergies, vitals, and past medical history were removed from these specific forms.

These changes streamline the patient intake process and ensure necessary foundational information is collected consistently before specialized evaluations, while also reducing data entry duplication.