### PR TITLE
It looks like you're working on adding diagnosis fields before recomm…

### DIFF
--- a/patient_evaluation_form/cervical.html
+++ b/patient_evaluation_form/cervical.html
@@ -485,6 +485,10 @@
     <fieldset class="mt-4">
         <legend>Recommendation: Outlines of initial plan of care</legend>
         <div class="mb-2">
+            <label for="cervical_specific_diagnosis" class="form-label">Cervical Specific Diagnosis:</label>
+            <textarea id="cervical_specific_diagnosis" name="cervical_specific_diagnosis" class="form-control form-control-sm" rows="3" placeholder="Enter specific diagnosis..."></textarea>
+        </div>
+        <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P4_Rec_Taping_chk" name="C_P4_Rec_Taping_chk" value="checked">
                 <label class="form-check-label" for="C_P4_Rec_Taping_chk">Taping / bracing</label>

--- a/patient_evaluation_form/lumbar.html
+++ b/patient_evaluation_form/lumbar.html
@@ -551,6 +551,10 @@
     <fieldset class="mt-4">
         <legend>Recommendation: Outline of Initial plan of care (Part 1)</legend>
         <div class="mb-2">
+            <label for="lumbar_specific_diagnosis" class="form-label">Lumbar Specific Diagnosis:</label>
+            <textarea id="lumbar_specific_diagnosis" name="lumbar_specific_diagnosis" class="form-control form-control-sm" rows="3" placeholder="Enter specific diagnosis..."></textarea>
+        </div>
+        <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P5_B17_LumboStab_chk" name="L_P5_B17_LumboStab_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B17_LumboStab_chk">Lumbopelvic Stabilization Program (B17)</label>

--- a/patient_evaluation_form/thoracic.html
+++ b/patient_evaluation_form/thoracic.html
@@ -528,6 +528,10 @@
     <fieldset class="mt-4">
         <legend>Recommendation - Outline of Initial Plan of care</legend>
         <div class="mb-2">
+            <label for="thoracic_specific_diagnosis" class="form-label">Thoracic Specific Diagnosis:</label>
+            <textarea id="thoracic_specific_diagnosis" name="thoracic_specific_diagnosis" class="form-control form-control-sm" rows="3" placeholder="Enter specific diagnosis..."></textarea>
+        </div>
+        <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B1" name="P4_B1" value="checked">
                 <label class="form-check-label" for="P4_B1">Modalities as Indicated</label>


### PR DESCRIPTION
…endations in clinical forms.

This commit addresses the requirement that a diagnosis input field must be present immediately before any recommendation section in clinical forms.

Modifications:
- In `patient_evaluation_form/cervical.html`: You added a 'Cervical Specific Diagnosis' textarea within the 'Recommendation' fieldset, before the recommendation options.
- In `patient_evaluation_form/lumbar.html`: You added a 'Lumbar Specific Diagnosis' textarea within the 'Recommendation: Outline of Initial plan of care (Part 1)' fieldset, before the recommendation options.
- In `patient_evaluation_form/thoracic.html`: You added a 'Thoracic Specific Diagnosis' textarea within the 'Recommendation - Outline of Initial Plan of care' fieldset, before the recommendation options.

These changes ensure that clinicians can record a specific diagnosis relevant to the recommendations being made within these specialized assessment forms.