### PR TITLE
Fix: Clean up login page diagnostics and fix login handler parse error.

### DIFF
--- a/pages/login.php
+++ b/pages/login.php
@@ -1,17 +1,4 @@
 <?php
-// DEBUGGING CODE BY JULES - START
-$templatePath = __DIR__ . '/../templates/layout/base.html.twig';
-if (file_exists($templatePath)) {
-    $templateContent = file_get_contents($templatePath);
-    echo "<pre>\nDEBUGGING base.html.twig (first 300 chars):\n";
-    echo htmlspecialchars(substr($templateContent, 0, 300));
-    echo "\n</pre>\n<hr>\n";
-} else {
-    echo "<pre>\nDEBUGGING: base.html.twig NOT FOUND at: " . htmlspecialchars($templatePath) . "</pre>\n<hr>\n";
-}
-die("Stopped by Jules' debug output.");
-// DEBUGGING CODE BY JULES - END
-
 // Define path to root for includes, assuming this file is in pages/
 $path_to_root = "../";
 

--- a/php/handle_login.php
+++ b/php/handle_login.php
@@ -72,6 +72,7 @@ try {
     SessionManager::set('login_error', 'Invalid username or password.'); // Specific login feedback
     header('Location: ../pages/login.php');
     exit;
+}
 } catch (PDOException $e) {
     // Use ErrorHandler to handle the exception
     // The ErrorHandler will log the error, set a generic session message, and redirect to error.php


### PR DESCRIPTION
- Removed temporary diagnostic code from pages/login.php.
- Fixed a parse error in php/handle_login.php by adding a missing closing curly brace for a try-catch block.

These changes prepare the login functionality for further testing.