### PR TITLE
Hotfix: Correct ErrorHandler redirect path for subfolder compatibility.

### DIFF
--- a/includes/ErrorHandler.php
+++ b/includes/ErrorHandler.php
@@ -24,8 +24,8 @@ class ErrorHandler {
         // For this subtask, we will redirect to a generic error page.
         // A more sophisticated approach might check the context (e.g., current page or type of exception)
         // For now, all exceptions handled by this will go to pages/error.php
-        // Using a root-relative path assuming 'pages' is directly under the web root.
-        header('Location: /pages/error.php');
+        // Reverting to relative path, assuming ErrorHandler.php is in includes/ and error.php is in pages/
+        header('Location: ../pages/error.php');
         exit;
     }
 


### PR DESCRIPTION
This addresses a potential cause for a "Not Found" error that could occur if an early exception on a page (e.g., dashboard) triggered the ErrorHandler. The previous absolute redirect path in ErrorHandler.php (`/pages/error.php`) would not work correctly if your application is installed in a subfolder.

Changed `includes/ErrorHandler.php` to use a relative redirect path (`../pages/error.php`) which correctly resolves from the `includes/` directory to the `pages/` directory, ensuring the error page can be reached reliably.