### PR TITLE
Fix: Correct column name for referential integrity rule

### DIFF
--- a/includes/setup_form_submissions_table.php
+++ b/includes/setup_form_submissions_table.php
@@ -59,7 +59,7 @@ try {
     }
 
     function getForeignKeyDefinition($pdo, $tableName, $constraintName) {
-        $sql = "SELECT REFERENTIAL_INTEGRITY_RULE FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
+        $sql = "SELECT DELETE_RULE FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
                 WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = ? AND CONSTRAINT_NAME = ? AND CONSTRAINT_TYPE = 'FOREIGN KEY'";
         $stmt = $pdo->prepare($sql);
         $stmt->execute([$tableName, $constraintName]);


### PR DESCRIPTION
Changed 'REFERENTIAL_INTEGRITY_RULE' to 'DELETE_RULE' in the getForeignKeyDefinition function in
includes/setup_form_submissions_table.php.

This resolves the "SQLSTATE[42S22]: Column not found: 1054 Unknown column 'REFERENTIAL_INTEGRITY_RULE' in 'field list'" error that occurred when the script was run on MySQL/MariaDB versions where the INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS table uses 'DELETE_RULE' instead of 'REFERENTIAL_INTEGRITY_RULE'.