### PR TITLE
Here's a commit message that implements conditional text inputs for c…

### DIFF
--- a/patient_evaluation_form/cervical.html
+++ b/patient_evaluation_form/cervical.html
@@ -338,56 +338,56 @@
                 <input class="form-check-input" type="checkbox" id="C_P2_Flex_UpperTrap_chk" name="C_P2_Flex_UpperTrap_chk" value="checked">
                 <label class="form-check-label" for="C_P2_Flex_UpperTrap_chk">Upper trap</label>
             </div>
-            <input type="text" id="C_P2_Flex_UpperTrap_txt" name="C_P2_Flex_UpperTrap_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P2_Flex_UpperTrap_txt" name="C_P2_Flex_UpperTrap_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P2_Flex_LevScap_chk" name="C_P2_Flex_LevScap_chk" value="checked">
                 <label class="form-check-label" for="C_P2_Flex_LevScap_chk">Lev. Scap</label>
             </div>
-            <input type="text" id="C_P2_Flex_LevScap_txt" name="C_P2_Flex_LevScap_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P2_Flex_LevScap_txt" name="C_P2_Flex_LevScap_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P2_Flex_SCM_chk" name="C_P2_Flex_SCM_chk" value="checked">
                 <label class="form-check-label" for="C_P2_Flex_SCM_chk">SCM</label>
             </div>
-            <input type="text" id="C_P2_Flex_SCM_txt" name="C_P2_Flex_SCM_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P2_Flex_SCM_txt" name="C_P2_Flex_SCM_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P2_Flex_SupTrapezius_chk" name="C_P2_Flex_SupTrapezius_chk" value="checked">
                 <label class="form-check-label" for="C_P2_Flex_SupTrapezius_chk">Superior trapezius</label>
             </div>
-            <input type="text" id="C_P2_Flex_SupTrapezius_txt" name="C_P2_Flex_SupTrapezius_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P2_Flex_SupTrapezius_txt" name="C_P2_Flex_SupTrapezius_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P2_Flex_Scalene_chk" name="C_P2_Flex_Scalene_chk" value="checked">
                 <label class="form-check-label" for="C_P2_Flex_Scalene_chk">Scalene</label>
             </div>
-            <input type="text" id="C_P2_Flex_Scalene_txt" name="C_P2_Flex_Scalene_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P2_Flex_Scalene_txt" name="C_P2_Flex_Scalene_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P2_Flex_Infraspinatus_chk" name="C_P2_Flex_Infraspinatus_chk" value="checked">
                 <label class="form-check-label" for="C_P2_Flex_Infraspinatus_chk">Infraspinatus</label>
             </div>
-            <input type="text" id="C_P2_Flex_Infraspinatus_txt" name="C_P2_Flex_Infraspinatus_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P2_Flex_Infraspinatus_txt" name="C_P2_Flex_Infraspinatus_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P2_Flex_Supraspinatus_chk" name="C_P2_Flex_Supraspinatus_chk" value="checked">
                 <label class="form-check-label" for="C_P2_Flex_Supraspinatus_chk">Supraspinatus</label>
             </div>
-            <input type="text" id="C_P2_Flex_Supraspinatus_txt" name="C_P2_Flex_Supraspinatus_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P2_Flex_Supraspinatus_txt" name="C_P2_Flex_Supraspinatus_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P2_Flex_Suboccipital_chk" name="C_P2_Flex_Suboccipital_chk" value="checked">
                 <label class="form-check-label" for="C_P2_Flex_Suboccipital_chk">Suboccipital muscle</label>
             </div>
-            <input type="text" id="C_P2_Flex_Suboccipital_txt" name="C_P2_Flex_Suboccipital_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P2_Flex_Suboccipital_txt" name="C_P2_Flex_Suboccipital_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         
         <div class="mb-2">
@@ -403,77 +403,77 @@
                 <input class="form-check-input" type="checkbox" id="C_P3_B29_chk" name="C_P3_B29_chk" value="checked">
                 <label class="form-check-label" for="C_P3_B29_chk">Postural Imbalance</label>
             </div>
-            <input type="text" id="C_P3_B40_txt" name="C_P3_B40_txt" class="form-control form-control-sm mt-1" placeholder="B40 details...">
+            <input type="text" id="C_P3_B40_txt" name="C_P3_B40_txt" class="form-control form-control-sm mt-1" placeholder="B40 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P3_B30_chk" name="C_P3_B30_chk" value="checked">
                 <label class="form-check-label" for="C_P3_B30_chk">Decreased AROM</label>
             </div>
-            <input type="text" id="C_P3_B41_txt" name="C_P3_B41_txt" class="form-control form-control-sm mt-1" placeholder="B41 details...">
+            <input type="text" id="C_P3_B41_txt" name="C_P3_B41_txt" class="form-control form-control-sm mt-1" placeholder="B41 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P3_B31_chk" name="C_P3_B31_chk" value="checked">
                 <label class="form-check-label" for="C_P3_B31_chk">Decreased passive intervertebral motion</label>
             </div>
-            <input type="text" id="C_P3_B42_txt" name="C_P3_B42_txt" class="form-control form-control-sm mt-1" placeholder="B42 details...">
+            <input type="text" id="C_P3_B42_txt" name="C_P3_B42_txt" class="form-control form-control-sm mt-1" placeholder="B42 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P3_B32_chk" name="C_P3_B32_chk" value="checked">
                 <label class="form-check-label" for="C_P3_B32_chk">Hypermobility on passive intervertebral motion</label>
             </div>
-            <input type="text" id="C_P3_B43_txt" name="C_P3_B43_txt" class="form-control form-control-sm mt-1" placeholder="B43 details...">
+            <input type="text" id="C_P3_B43_txt" name="C_P3_B43_txt" class="form-control form-control-sm mt-1" placeholder="B43 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P3_B33_chk" name="C_P3_B33_chk" value="checked">
                 <label class="form-check-label" for="C_P3_B33_chk">Decreased strength of Cervical and UQ muscles</label>
             </div>
-            <input type="text" id="C_P3_B44_txt" name="C_P3_B44_txt" class="form-control form-control-sm mt-1" placeholder="B44 details...">
+            <input type="text" id="C_P3_B44_txt" name="C_P3_B44_txt" class="form-control form-control-sm mt-1" placeholder="B44 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P3_B34_chk" name="C_P3_B34_chk" value="checked">
                 <label class="form-check-label" for="C_P3_B34_chk">Hypertonic upper quarter musculature</label>
             </div>
-            <input type="text" id="C_P3_B45_txt" name="C_P3_B45_txt" class="form-control form-control-sm mt-1" placeholder="B45 details...">
+            <input type="text" id="C_P3_B45_txt" name="C_P3_B45_txt" class="form-control form-control-sm mt-1" placeholder="B45 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P3_B35_chk" name="C_P3_B35_chk" value="checked">
                 <label class="form-check-label" for="C_P3_B35_chk">Adaptive shortening of muscles</label>
             </div>
-            <input type="text" id="C_P3_B46_txt" name="C_P3_B46_txt" class="form-control form-control-sm mt-1" placeholder="B46 details...">
+            <input type="text" id="C_P3_B46_txt" name="C_P3_B46_txt" class="form-control form-control-sm mt-1" placeholder="B46 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P3_B36_chk" name="C_P3_B36_chk" value="checked">
                 <label class="form-check-label" for="C_P3_B36_chk">Adverse neural tension</label>
             </div>
-            <input type="text" id="C_P3_B47_txt" name="C_P3_B47_txt" class="form-control form-control-sm mt-1" placeholder="B47 details...">
+            <input type="text" id="C_P3_B47_txt" name="C_P3_B47_txt" class="form-control form-control-sm mt-1" placeholder="B47 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P3_B37_chk" name="C_P3_B37_chk" value="checked">
                 <label class="form-check-label" for="C_P3_B37_chk">Decreased facet joint mobility</label>
             </div>
-            <input type="text" id="C_P3_B48_txt" name="C_P3_B48_txt" class="form-control form-control-sm mt-1" placeholder="B48 details...">
+            <input type="text" id="C_P3_B48_txt" name="C_P3_B48_txt" class="form-control form-control-sm mt-1" placeholder="B48 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P3_B38_chk" name="C_P3_B38_chk" value="checked">
                 <label class="form-check-label" for="C_P3_B38_chk">Decreased mobility upper thoracic Spine</label>
             </div>
-            <input type="text" id="C_P3_B49_txt" name="C_P3_B49_txt" class="form-control form-control-sm mt-1" placeholder="B49 details...">
+            <input type="text" id="C_P3_B49_txt" name="C_P3_B49_txt" class="form-control form-control-sm mt-1" placeholder="B49 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P3_B39_chk" name="C_P3_B39_chk" value="checked">
                 <label class="form-check-label" for="C_P3_B39_chk">Restricted mobility Suboccipital</label>
             </div>
-            <input type="text" id="C_P3_B50_txt" name="C_P3_B50_txt" class="form-control form-control-sm mt-1" placeholder="B50 details...">
+            <input type="text" id="C_P3_B50_txt" name="C_P3_B50_txt" class="form-control form-control-sm mt-1" placeholder="B50 details..." disabled>
         </div>
         
         <div class="mb-2">
@@ -493,98 +493,98 @@
                 <input class="form-check-input" type="checkbox" id="C_P4_Rec_Taping_chk" name="C_P4_Rec_Taping_chk" value="checked">
                 <label class="form-check-label" for="C_P4_Rec_Taping_chk">Taping / bracing</label>
             </div>
-            <input type="text" id="C_P4_Rec_Taping_txt" name="C_P4_Rec_Taping_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P4_Rec_Taping_txt" name="C_P4_Rec_Taping_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P4_Rec_CervStab_chk" name="C_P4_Rec_CervStab_chk" value="checked">
                 <label class="form-check-label" for="C_P4_Rec_CervStab_chk">Cervical stabilization program</label>
             </div>
-            <input type="text" id="C_P4_Rec_CervStab_txt" name="C_P4_Rec_CervStab_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P4_Rec_CervStab_txt" name="C_P4_Rec_CervStab_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P4_Rec_CervROM_chk" name="C_P4_Rec_CervROM_chk" value="checked">
                 <label class="form-check-label" for="C_P4_Rec_CervROM_chk">Cervical range of motion</label>
             </div>
-            <input type="text" id="C_P4_Rec_CervROM_txt" name="C_P4_Rec_CervROM_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P4_Rec_CervROM_txt" name="C_P4_Rec_CervROM_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P4_Rec_ThorROM_chk" name="C_P4_Rec_ThorROM_chk" value="checked">
                 <label class="form-check-label" for="C_P4_Rec_ThorROM_chk">Thoracic range of motion</label>
             </div>
-            <input type="text" id="C_P4_Rec_ThorROM_txt" name="C_P4_Rec_ThorROM_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P4_Rec_ThorROM_txt" name="C_P4_Rec_ThorROM_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P4_Rec_CervMob_chk" name="C_P4_Rec_CervMob_chk" value="checked">
                 <label class="form-check-label" for="C_P4_Rec_CervMob_chk">Cervical mobilization</label>
             </div>
-            <input type="text" id="C_P4_Rec_CervMob_txt" name="C_P4_Rec_CervMob_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P4_Rec_CervMob_txt" name="C_P4_Rec_CervMob_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P4_Rec_ThorMob_chk" name="C_P4_Rec_ThorMob_chk" value="checked">
                 <label class="form-check-label" for="C_P4_Rec_ThorMob_chk">Thoracic mobilization</label>
             </div>
-            <input type="text" id="C_P4_Rec_ThorMob_txt" name="C_P4_Rec_ThorMob_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P4_Rec_ThorMob_txt" name="C_P4_Rec_ThorMob_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P4_Rec_CervTraction_chk" name="C_P4_Rec_CervTraction_chk" value="checked">
                 <label class="form-check-label" for="C_P4_Rec_CervTraction_chk">Cervical traction</label>
             </div>
-            <input type="text" id="C_P4_Rec_CervTraction_txt" name="C_P4_Rec_CervTraction_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P4_Rec_CervTraction_txt" name="C_P4_Rec_CervTraction_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P4_Rec_SoftTissue_chk" name="C_P4_Rec_SoftTissue_chk" value="checked">
                 <label class="form-check-label" for="C_P4_Rec_SoftTissue_chk">Soft tissue mobilization</label>
             </div>
-            <input type="text" id="C_P4_Rec_SoftTissue_txt" name="C_P4_Rec_SoftTissue_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P4_Rec_SoftTissue_txt" name="C_P4_Rec_SoftTissue_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P4_Rec_NeuralMob_chk" name="C_P4_Rec_NeuralMob_chk" value="checked">
                 <label class="form-check-label" for="C_P4_Rec_NeuralMob_chk">Neural mobilization</label>
             </div>
-            <input type="text" id="C_P4_Rec_NeuralMob_txt" name="C_P4_Rec_NeuralMob_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P4_Rec_NeuralMob_txt" name="C_P4_Rec_NeuralMob_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P4_Rec_PostureEd_chk" name="C_P4_Rec_PostureEd_chk" value="checked">
                 <label class="form-check-label" for="C_P4_Rec_PostureEd_chk">Posture education & awareness ex</label>
             </div>
-            <input type="text" id="C_P4_Rec_PostureEd_txt" name="C_P4_Rec_PostureEd_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P4_Rec_PostureEd_txt" name="C_P4_Rec_PostureEd_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P4_Rec_BodyMech_chk" name="C_P4_Rec_BodyMech_chk" value="checked">
                 <label class="form-check-label" for="C_P4_Rec_BodyMech_chk">Instruction in body mechanics</label>
             </div>
-            <input type="text" id="C_P4_Rec_BodyMech_txt" name="C_P4_Rec_BodyMech_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P4_Rec_BodyMech_txt" name="C_P4_Rec_BodyMech_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P4_Rec_TriggerPoint_chk" name="C_P4_Rec_TriggerPoint_chk" value="checked">
                 <label class="form-check-label" for="C_P4_Rec_TriggerPoint_chk">Trigger point release</label>
             </div>
-            <input type="text" id="C_P4_Rec_TriggerPoint_txt" name="C_P4_Rec_TriggerPoint_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P4_Rec_TriggerPoint_txt" name="C_P4_Rec_TriggerPoint_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P4_Rec_ExStrength_chk" name="C_P4_Rec_ExStrength_chk" value="checked">
                 <label class="form-check-label" for="C_P4_Rec_ExStrength_chk">Exercises to improve strength, [flexibility]</label>
             </div>
-            <input type="text" id="C_P4_Rec_ExStrength_txt" name="C_P4_Rec_ExStrength_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P4_Rec_ExStrength_txt" name="C_P4_Rec_ExStrength_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="C_P4_Rec_DryNeedling_chk" name="C_P4_Rec_DryNeedling_chk" value="checked">
                 <label class="form-check-label" for="C_P4_Rec_DryNeedling_chk">Dry needling</label>
             </div>
-            <input type="text" id="C_P4_Rec_DryNeedling_txt" name="C_P4_Rec_DryNeedling_txt" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="C_P4_Rec_DryNeedling_txt" name="C_P4_Rec_DryNeedling_txt" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
     </fieldset>
 
@@ -625,6 +625,81 @@
   document.addEventListener('DOMContentLoaded', function() {
     initFormSubmissionHandler('cervicalAssessmentForm', 'cervicalAssessmentForm-message');
   });
+</script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const formIds = ['cervicalAssessmentForm', 'lumbarAssessmentForm', 'thoracicAssessmentForm'];
+    formIds.forEach(formId => {
+        const form = document.getElementById(formId);
+        if (!form) return;
+
+        const checkboxes = form.querySelectorAll('input[type="checkbox"]');
+        checkboxes.forEach(function(checkbox) {
+            let associatedTextInput = null;
+            const parentWrapper = checkbox.closest('.mb-2'); // Common wrapper for a checkbox and its related text input
+
+            if (parentWrapper) {
+                // Attempt 1: Text input is a direct child of parentWrapper and not in a .form-check div
+                associatedTextInput = parentWrapper.querySelector('input[type="text"]:not(.form-check-input), textarea:not(.form-check-input)');
+
+                // Refinement: Ensure the found text input is not part of another checkbox's immediate .form-check parent,
+                // unless it's the one being sought. This is tricky.
+                // A simpler structural assumption: the text input is a sibling of the checkbox's .form-check div,
+                // both being children of parentWrapper.
+                const formCheckDiv = checkbox.closest('.form-check');
+                if (formCheckDiv && formCheckDiv.parentElement === parentWrapper) {
+                    let nextSibling = formCheckDiv.nextElementSibling;
+                    if (nextSibling && (nextSibling.matches('input[type="text"]') || nextSibling.matches('textarea'))) {
+                        associatedTextInput = nextSibling;
+                    } else {
+                        // If not an immediate sibling, it might be a bit further, but still within parentWrapper.
+                        // This will re-select if the above didn't find it.
+                         associatedTextInput = parentWrapper.querySelector('input[type="text"], textarea');
+                         // Verify it's not inside another form-check or something unexpected
+                         if (associatedTextInput && associatedTextInput.closest('.form-check') && associatedTextInput.closest('.form-check') !== formCheckDiv) {
+                            associatedTextInput = null; // It belongs to another checkbox construct
+                         } else if (associatedTextInput && associatedTextInput.parentElement !== parentWrapper && associatedTextInput.parentElement !== formCheckDiv.parentElement) {
+                            // If it's too nested or not a direct child as expected, ignore
+                            // This condition might be too strict depending on actual variations
+                         }
+                    }
+                }
+            }
+
+            // Fallback or primary for IDs like X_chk and X_txt
+            if (!associatedTextInput && checkbox.id && checkbox.id.includes('_chk')) {
+                const textInputId = checkbox.id.replace('_chk', '_txt');
+                const potentialTextInput = document.getElementById(textInputId);
+                if (potentialTextInput && (potentialTextInput.type === 'text' || potentialTextInput.type === 'textarea')) {
+                    associatedTextInput = potentialTextInput;
+                }
+            }
+
+            // Another fallback for thoracic.html like P2_B1 (checkbox) and P2_B5 (text)
+            // This requires a more specific mapping if IDs are not systematically related.
+            // For now, relying on structure or _chk/_txt convention.
+
+            if (associatedTextInput) {
+                // Ensure HTML already has 'disabled' for initial state on page load.
+                // JS will manage it from now on.
+                // associatedTextInput.disabled = !checkbox.checked; // Set initial state via JS too
+                // if (!checkbox.checked) {
+                //    associatedTextInput.value = '';
+                // }
+
+                checkbox.addEventListener('change', function() {
+                    associatedTextInput.disabled = !this.checked;
+                    if (!this.checked) {
+                        associatedTextInput.value = ''; // Clear value when unchecked
+                    } else {
+                        // Optional: focus the text input when checkbox is checked
+                        // associatedTextInput.focus();
+                    }
+                });
+            }
+        });
+    });
+});
 </script>
 </body>
 </html>

--- a/patient_evaluation_form/lumbar.html
+++ b/patient_evaluation_form/lumbar.html
@@ -212,28 +212,28 @@
                 <input class="form-check-input" type="checkbox" id="L_P2_B6_NormalMob_chk" name="L_P2_B6_NormalMob_chk" value="checked">
                 <label class="form-check-label" for="L_P2_B6_NormalMob_chk">Normal Mobility (B6)</label>
             </div>
-            <input type="text" id="L_P2_B10_NormalMob_txt" name="L_P2_B10_NormalMob_txt" class="form-control form-control-sm mt-1" placeholder="B10 details...">
+            <input type="text" id="L_P2_B10_NormalMob_txt" name="L_P2_B10_NormalMob_txt" class="form-control form-control-sm mt-1" placeholder="B10 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P2_B7_Stiff_chk" name="L_P2_B7_Stiff_chk" value="checked">
                 <label class="form-check-label" for="L_P2_B7_Stiff_chk">Stiff throughout (B7)</label>
             </div>
-            <input type="text" id="L_P2_B11_Stiff_txt" name="L_P2_B11_Stiff_txt" class="form-control form-control-sm mt-1" placeholder="B11 details...">
+            <input type="text" id="L_P2_B11_Stiff_txt" name="L_P2_B11_Stiff_txt" class="form-control form-control-sm mt-1" placeholder="B11 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P2_B8_ResRightRot_chk" name="L_P2_B8_ResRightRot_chk" value="checked">
                 <label class="form-check-label" for="L_P2_B8_ResRightRot_chk">Restricted Right Rotation (B8)</label>
             </div>
-            <input type="text" id="L_P2_B12_ResRightRot_txt" name="L_P2_B12_ResRightRot_txt" class="form-control form-control-sm mt-1" placeholder="B12 details...">
+            <input type="text" id="L_P2_B12_ResRightRot_txt" name="L_P2_B12_ResRightRot_txt" class="form-control form-control-sm mt-1" placeholder="B12 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P2_B9_ResLeftRot_chk" name="L_P2_B9_ResLeftRot_chk" value="checked">
                 <label class="form-check-label" for="L_P2_B9_ResLeftRot_chk">Restricted Left Rotation (B9)</label>
             </div>
-            <input type="text" id="L_P2_B13_ResLeftRot_txt" name="L_P2_B13_ResLeftRot_txt" class="form-control form-control-sm mt-1" placeholder="B13 details...">
+            <input type="text" id="L_P2_B13_ResLeftRot_txt" name="L_P2_B13_ResLeftRot_txt" class="form-control form-control-sm mt-1" placeholder="B13 details..." disabled>
         </div>
         
         <div class="mb-2">
@@ -243,7 +243,7 @@
                 <option value="L3/L4">L3/L4</option><option value="L4/L5">L4/L5</option>
                 <option value="L5/S1">L5/S1</option>
             </select>
-            <input type="text" id="L_P2_B15_Hypermob_txt" name="L_P2_B15_Hypermob_txt" class="form-control form-control-sm mt-1" placeholder="B15 details (additional notes)...">
+            <input type="text" id="L_P2_B15_Hypermob_txt" name="L_P2_B15_Hypermob_txt" class="form-control form-control-sm mt-1" placeholder="B15 details (additional notes)..." disabled>
         </div>
     </fieldset>
 
@@ -421,70 +421,70 @@
                 <input class="form-check-input" type="checkbox" id="L_P4_B6_FuncInstability_chk" name="L_P4_B6_FuncInstability_chk" value="checked">
                 <label class="form-check-label" for="L_P4_B6_FuncInstability_chk">Functional Instability of lumbopelvic region (B6)</label>
             </div>
-            <input type="text" id="L_P4_B16_FuncInstability_txt" name="L_P4_B16_FuncInstability_txt" class="form-control form-control-sm mt-1" placeholder="B16 details...">
+            <input type="text" id="L_P4_B16_FuncInstability_txt" name="L_P4_B16_FuncInstability_txt" class="form-control form-control-sm mt-1" placeholder="B16 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P4_B7_LumbarSpineDys_chk" name="L_P4_B7_LumbarSpineDys_chk" value="checked">
                 <label class="form-check-label" for="L_P4_B7_LumbarSpineDys_chk">Lumbar spine dysfunction (B7)</label>
             </div>
-            <input type="text" id="L_P4_B17_LumbarSpineDys_txt" name="L_P4_B17_LumbarSpineDys_txt" class="form-control form-control-sm mt-1" placeholder="B17 details...">
+            <input type="text" id="L_P4_B17_LumbarSpineDys_txt" name="L_P4_B17_LumbarSpineDys_txt" class="form-control form-control-sm mt-1" placeholder="B17 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P4_B8_DecLumbarActiveROM_chk" name="L_P4_B8_DecLumbarActiveROM_chk" value="checked">
                 <label class="form-check-label" for="L_P4_B8_DecLumbarActiveROM_chk">Decreased lumbar spine active range of motion (B8)</label>
             </div>
-            <input type="text" id="L_P4_B18_DecLumbarActiveROM_txt" name="L_P4_B18_DecLumbarActiveROM_txt" class="form-control form-control-sm mt-1" placeholder="B18 details...">
+            <input type="text" id="L_P4_B18_DecLumbarActiveROM_txt" name="L_P4_B18_DecLumbarActiveROM_txt" class="form-control form-control-sm mt-1" placeholder="B18 details..." disabled>
         </div>
          <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P4_B9_LumbarHypermob_chk" name="L_P4_B9_LumbarHypermob_chk" value="checked">
                 <label class="form-check-label" for="L_P4_B9_LumbarHypermob_chk">Lumbar hypermobility (B9)</label>
             </div>
-            <input type="text" id="L_P4_B19_LumbarHypermob_txt" name="L_P4_B19_LumbarHypermob_txt" class="form-control form-control-sm mt-1" placeholder="B19 details...">
+            <input type="text" id="L_P4_B19_LumbarHypermob_txt" name="L_P4_B19_LumbarHypermob_txt" class="form-control form-control-sm mt-1" placeholder="B19 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P4_B10_FacetHypermob_chk" name="L_P4_B10_FacetHypermob_chk" value="checked">
                 <label class="form-check-label" for="L_P4_B10_FacetHypermob_chk">Facet Joint hypermobility lumbar | thoracic spine (B10)</label>
             </div>
-            <input type="text" id="L_P4_B20_FacetHypermob_txt" name="L_P4_B20_FacetHypermob_txt" class="form-control form-control-sm mt-1" placeholder="B20 details...">
+            <input type="text" id="L_P4_B20_FacetHypermob_txt" name="L_P4_B20_FacetHypermob_txt" class="form-control form-control-sm mt-1" placeholder="B20 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P4_B11_S1DysHypermob_chk" name="L_P4_B11_S1DysHypermob_chk" value="checked">
                 <label class="form-check-label" for="L_P4_B11_S1DysHypermob_chk">S-1 dysfunction with possible hypermobility (B11)</label>
             </div>
-            <input type="text" id="L_P4_B21_S1DysHypermob_txt" name="L_P4_B21_S1DysHypermob_txt" class="form-control form-control-sm mt-1" placeholder="B21 details...">
+            <input type="text" id="L_P4_B21_S1DysHypermob_txt" name="L_P4_B21_S1DysHypermob_txt" class="form-control form-control-sm mt-1" placeholder="B21 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P4_B12_SensitiveVert_chk" name="L_P4_B12_SensitiveVert_chk" value="checked">
                 <label class="form-check-label" for="L_P4_B12_SensitiveVert_chk">Sensitive vertebra to a P-a oscillations (B12)</label>
             </div>
-            <input type="text" id="L_P4_B22_SensitiveVert_txt" name="L_P4_B22_SensitiveVert_txt" class="form-control form-control-sm mt-1" placeholder="B22 details...">
+            <input type="text" id="L_P4_B22_SensitiveVert_txt" name="L_P4_B22_SensitiveVert_txt" class="form-control form-control-sm mt-1" placeholder="B22 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P4_B13_Rotoscoliosis_chk" name="L_P4_B13_Rotoscoliosis_chk" value="checked">
                 <label class="form-check-label" for="L_P4_B13_Rotoscoliosis_chk">Rotoscoliosis (B13)</label>
             </div>
-            <input type="text" id="L_P4_B23_Rotoscoliosis_txt" name="L_P4_B23_Rotoscoliosis_txt" class="form-control form-control-sm mt-1" placeholder="B23 details...">
+            <input type="text" id="L_P4_B23_Rotoscoliosis_txt" name="L_P4_B23_Rotoscoliosis_txt" class="form-control form-control-sm mt-1" placeholder="B23 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P4_B14_HipCapsuleRes_chk" name="L_P4_B14_HipCapsuleRes_chk" value="checked">
                 <label class="form-check-label" for="L_P4_B14_HipCapsuleRes_chk">Hip capsule restriction (B14)</label>
             </div>
-            <input type="text" id="L_P4_B24_HipCapsuleRes_txt" name="L_P4_B24_HipCapsuleRes_txt" class="form-control form-control-sm mt-1" placeholder="B24 details...">
+            <input type="text" id="L_P4_B24_HipCapsuleRes_txt" name="L_P4_B24_HipCapsuleRes_txt" class="form-control form-control-sm mt-1" placeholder="B24 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P4_B15_HipFlexorDys_chk" name="L_P4_B15_HipFlexorDys_chk" value="checked">
                 <label class="form-check-label" for="L_P4_B15_HipFlexorDys_chk">Hip Flexor muscle dysfunction (B15)</label>
             </div>
-            <input type="text" id="L_P4_B25_HipFlexorDys_txt" name="L_P4_B25_HipFlexorDys_txt" class="form-control form-control-sm mt-1" placeholder="B25 details...">
+            <input type="text" id="L_P4_B25_HipFlexorDys_txt" name="L_P4_B25_HipFlexorDys_txt" class="form-control form-control-sm mt-1" placeholder="B25 details..." disabled>
         </div>
     </fieldset>
 
@@ -495,56 +495,56 @@
                 <input class="form-check-input" type="checkbox" id="L_P5_B1_HypertonicMusc_chk" name="L_P5_B1_HypertonicMusc_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B1_HypertonicMusc_chk">Hypertonic Musculature (B1)</label>
             </div>
-            <input type="text" id="L_P5_B9_HypertonicMusc_txt" name="L_P5_B9_HypertonicMusc_txt" class="form-control form-control-sm mt-1" placeholder="B9 details...">
+            <input type="text" id="L_P5_B9_HypertonicMusc_txt" name="L_P5_B9_HypertonicMusc_txt" class="form-control form-control-sm mt-1" placeholder="B9 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P5_B2_DecLowerExtMuscLen_chk" name="L_P5_B2_DecLowerExtMuscLen_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B2_DecLowerExtMuscLen_chk">Decreased lower extremity Muscle length (B2)</label>
             </div>
-            <input type="text" id="L_P5_B10_DecLowerExtMuscLen_txt" name="L_P5_B10_DecLowerExtMuscLen_txt" class="form-control form-control-sm mt-1" placeholder="B10 details...">
+            <input type="text" id="L_P5_B10_DecLowerExtMuscLen_txt" name="L_P5_B10_DecLowerExtMuscLen_txt" class="form-control form-control-sm mt-1" placeholder="B10 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P5_B3_AdverseNeuralTension_chk" name="L_P5_B3_AdverseNeuralTension_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B3_AdverseNeuralTension_chk">Adverse neural tension sign Sciatic and femoral tract (B3)</label>
             </div>
-            <input type="text" id="L_P5_B11_AdverseNeuralTension_txt" name="L_P5_B11_AdverseNeuralTension_txt" class="form-control form-control-sm mt-1" placeholder="B11 details...">
+            <input type="text" id="L_P5_B11_AdverseNeuralTension_txt" name="L_P5_B11_AdverseNeuralTension_txt" class="form-control form-control-sm mt-1" placeholder="B11 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P5_B4_GaitDysfunction_chk" name="L_P5_B4_GaitDysfunction_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B4_GaitDysfunction_chk">Gait dysfunction (B4)</label>
             </div>
-            <input type="text" id="L_P5_B12_GaitDysfunction_txt" name="L_P5_B12_GaitDysfunction_txt" class="form-control form-control-sm mt-1" placeholder="B12 details...">
+            <input type="text" id="L_P5_B12_GaitDysfunction_txt" name="L_P5_B12_GaitDysfunction_txt" class="form-control form-control-sm mt-1" placeholder="B12 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P5_B5_LongQuadrant_chk" name="L_P5_B5_LongQuadrant_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B5_LongQuadrant_chk">Long Quadrant (B5)</label>
             </div>
-            <input type="text" id="L_P5_B13_LongQuadrant_txt" name="L_P5_B13_LongQuadrant_txt" class="form-control form-control-sm mt-1" placeholder="B13 details...">
+            <input type="text" id="L_P5_B13_LongQuadrant_txt" name="L_P5_B13_LongQuadrant_txt" class="form-control form-control-sm mt-1" placeholder="B13 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P5_B6_AltMechSupTibFib_chk" name="L_P5_B6_AltMechSupTibFib_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B6_AltMechSupTibFib_chk">Altered mechanics superior tib/fib Joint (B6)</label>
             </div>
-            <input type="text" id="L_P5_B14_AltMechSupTibFib_txt" name="L_P5_B14_AltMechSupTibFib_txt" class="form-control form-control-sm mt-1" placeholder="B14 details...">
+            <input type="text" id="L_P5_B14_AltMechSupTibFib_txt" name="L_P5_B14_AltMechSupTibFib_txt" class="form-control form-control-sm mt-1" placeholder="B14 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P5_B7_AltMechAnkle_chk" name="L_P5_B7_AltMechAnkle_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B7_AltMechAnkle_chk">Altered mechanics of Ankle Joint (B7)</label>
             </div>
-            <input type="text" id="L_P5_B15_AltMechAnkle_txt" name="L_P5_B15_AltMechAnkle_txt" class="form-control form-control-sm mt-1" placeholder="B15 details...">
+            <input type="text" id="L_P5_B15_AltMechAnkle_txt" name="L_P5_B15_AltMechAnkle_txt" class="form-control form-control-sm mt-1" placeholder="B15 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P5_B8_GenPhyDiscond_chk" name="L_P5_B8_GenPhyDiscond_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B8_GenPhyDiscond_chk">Generalized physical disconditioning (B8)</label>
             </div>
-            <input type="text" id="L_P5_B16_GenPhyDiscond_txt" name="L_P5_B16_GenPhyDiscond_txt" class="form-control form-control-sm mt-1" placeholder="B16 details...">
+            <input type="text" id="L_P5_B16_GenPhyDiscond_txt" name="L_P5_B16_GenPhyDiscond_txt" class="form-control form-control-sm mt-1" placeholder="B16 details..." disabled>
         </div>
     </fieldset>
 
@@ -559,56 +559,56 @@
                 <input class="form-check-input" type="checkbox" id="L_P5_B17_LumboStab_chk" name="L_P5_B17_LumboStab_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B17_LumboStab_chk">Lumbopelvic Stabilization Program (B17)</label>
             </div>
-            <input type="text" id="L_P5_B25_LumboStab_txt" name="L_P5_B25_LumboStab_txt" class="form-control form-control-sm mt-1" placeholder="B25 details...">
+            <input type="text" id="L_P5_B25_LumboStab_txt" name="L_P5_B25_LumboStab_txt" class="form-control form-control-sm mt-1" placeholder="B25 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P5_B18_TapingLumbar_chk" name="L_P5_B18_TapingLumbar_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B18_TapingLumbar_chk">Taping/bracing of lumbar spine (B18)</label>
             </div>
-            <input type="text" id="L_P5_B26_TapingLumbar_txt" name="L_P5_B26_TapingLumbar_txt" class="form-control form-control-sm mt-1" placeholder="B26 details...">
+            <input type="text" id="L_P5_B26_TapingLumbar_txt" name="L_P5_B26_TapingLumbar_txt" class="form-control form-control-sm mt-1" placeholder="B26 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P5_B19_LumbarROM_chk" name="L_P5_B19_LumbarROM_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B19_LumbarROM_chk">Lumbar range of motion (B19)</label>
             </div>
-            <input type="text" id="L_P5_B27_LumbarROM_txt" name="L_P5_B27_LumbarROM_txt" class="form-control form-control-sm mt-1" placeholder="B27 details...">
+            <input type="text" id="L_P5_B27_LumbarROM_txt" name="L_P5_B27_LumbarROM_txt" class="form-control form-control-sm mt-1" placeholder="B27 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P5_B20_ThoracicROMEx_chk" name="L_P5_B20_ThoracicROMEx_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B20_ThoracicROMEx_chk">Thoracic range of motion Exercise (B20)</label>
             </div>
-            <input type="text" id="L_P5_B28_ThoracicROMEx_txt" name="L_P5_B28_ThoracicROMEx_txt" class="form-control form-control-sm mt-1" placeholder="B28 details...">
+            <input type="text" id="L_P5_B28_ThoracicROMEx_txt" name="L_P5_B28_ThoracicROMEx_txt" class="form-control form-control-sm mt-1" placeholder="B28 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P5_B21_ThoracicMob_chk" name="L_P5_B21_ThoracicMob_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B21_ThoracicMob_chk">Thoracic Mobilization (B21)</label>
             </div>
-            <input type="text" id="L_P5_B29_ThoracicMob_txt" name="L_P5_B29_ThoracicMob_txt" class="form-control form-control-sm mt-1" placeholder="B29 details...">
+            <input type="text" id="L_P5_B29_ThoracicMob_txt" name="L_P5_B29_ThoracicMob_txt" class="form-control form-control-sm mt-1" placeholder="B29 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P5_B22_LumbarMob_chk" name="L_P5_B22_LumbarMob_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B22_LumbarMob_chk">Lumbar Mobilization (B22)</label>
             </div>
-            <input type="text" id="L_P5_B30_LumbarMob_txt" name="L_P5_B30_LumbarMob_txt" class="form-control form-control-sm mt-1" placeholder="B30 details...">
+            <input type="text" id="L_P5_B30_LumbarMob_txt" name="L_P5_B30_LumbarMob_txt" class="form-control form-control-sm mt-1" placeholder="B30 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P5_B23_HipMob_chk" name="L_P5_B23_HipMob_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B23_HipMob_chk">Hip mobilization (B23)</label>
             </div>
-            <input type="text" id="L_P5_B31_HipMob_txt" name="L_P5_B31_HipMob_txt" class="form-control form-control-sm mt-1" placeholder="B31 details...">
+            <input type="text" id="L_P5_B31_HipMob_txt" name="L_P5_B31_HipMob_txt" class="form-control form-control-sm mt-1" placeholder="B31 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P5_B24_LumbarTraction_chk" name="L_P5_B24_LumbarTraction_chk" value="checked">
                 <label class="form-check-label" for="L_P5_B24_LumbarTraction_chk">Lumbar traction (B24)</label>
             </div>
-            <input type="text" id="L_P5_B32_LumbarTraction_txt" name="L_P5_B32_LumbarTraction_txt" class="form-control form-control-sm mt-1" placeholder="B32 details...">
+            <input type="text" id="L_P5_B32_LumbarTraction_txt" name="L_P5_B32_LumbarTraction_txt" class="form-control form-control-sm mt-1" placeholder="B32 details..." disabled>
         </div>
     </fieldset>
 
@@ -619,112 +619,112 @@
                 <input class="form-check-input" type="checkbox" id="L_P6_B1_StabBeltPelvis_chk" name="L_P6_B1_StabBeltPelvis_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B1_StabBeltPelvis_chk">Stabilization belt for pelvis (B1)</label>
             </div>
-            <input type="text" id="L_P6_B17_StabBeltPelvis_txt" name="L_P6_B17_StabBeltPelvis_txt" class="form-control form-control-sm mt-1" placeholder="B17 details...">
+            <input type="text" id="L_P6_B17_StabBeltPelvis_txt" name="L_P6_B17_StabBeltPelvis_txt" class="form-control form-control-sm mt-1" placeholder="B17 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P6_B2_S1Mob_chk" name="L_P6_B2_S1Mob_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B2_S1Mob_chk">S-1 Mobilization (B2)</label>
             </div>
-            <input type="text" id="L_P6_B18_S1Mob_txt" name="L_P6_B18_S1Mob_txt" class="form-control form-control-sm mt-1" placeholder="B18 details...">
+            <input type="text" id="L_P6_B18_S1Mob_txt" name="L_P6_B18_S1Mob_txt" class="form-control form-control-sm mt-1" placeholder="B18 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P6_B3_HipROM_chk" name="L_P6_B3_HipROM_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B3_HipROM_chk">Hip Range of Motion (B3)</label>
             </div>
-            <input type="text" id="L_P6_B19_HipROM_txt" name="L_P6_B19_HipROM_txt" class="form-control form-control-sm mt-1" placeholder="B19 details...">
+            <input type="text" id="L_P6_B19_HipROM_txt" name="L_P6_B19_HipROM_txt" class="form-control form-control-sm mt-1" placeholder="B19 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P6_B4_SoftTissuePelvic_chk" name="L_P6_B4_SoftTissuePelvic_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B4_SoftTissuePelvic_chk">Soft tissue mobilization pelvic girdle Musculature (B4)</label>
             </div>
-            <input type="text" id="L_P6_B20_SoftTissuePelvic_txt" name="L_P6_B20_SoftTissuePelvic_txt" class="form-control form-control-sm mt-1" placeholder="B20 details...">
+            <input type="text" id="L_P6_B20_SoftTissuePelvic_txt" name="L_P6_B20_SoftTissuePelvic_txt" class="form-control form-control-sm mt-1" placeholder="B20 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P6_B5_LengthHipMusc_chk" name="L_P6_B5_LengthHipMusc_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B5_LengthHipMusc_chk">Lengthening and Stretching of Hip Musculature (B5)</label>
             </div>
-            <input type="text" id="L_P6_B21_LengthHipMusc_txt" name="L_P6_B21_LengthHipMusc_txt" class="form-control form-control-sm mt-1" placeholder="B21 details...">
+            <input type="text" id="L_P6_B21_LengthHipMusc_txt" name="L_P6_B21_LengthHipMusc_txt" class="form-control form-control-sm mt-1" placeholder="B21 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P6_B6_NeuralMob_chk" name="L_P6_B6_NeuralMob_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B6_NeuralMob_chk">Neural Mobilization (B6)</label>
             </div>
-            <input type="text" id="L_P6_B22_NeuralMob_txt" name="L_P6_B22_NeuralMob_txt" class="form-control form-control-sm mt-1" placeholder="B22 details...">
+            <input type="text" id="L_P6_B22_NeuralMob_txt" name="L_P6_B22_NeuralMob_txt" class="form-control form-control-sm mt-1" placeholder="B22 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P6_B7_PostureEd_chk" name="L_P6_B7_PostureEd_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B7_PostureEd_chk">Posture Education and Awareness Exercise (B7)</label>
             </div>
-            <input type="text" id="L_P6_B23_PostureEd_txt" name="L_P6_B23_PostureEd_txt" class="form-control form-control-sm mt-1" placeholder="B23 details...">
+            <input type="text" id="L_P6_B23_PostureEd_txt" name="L_P6_B23_PostureEd_txt" class="form-control form-control-sm mt-1" placeholder="B23 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P6_B8_BodyMech_chk" name="L_P6_B8_BodyMech_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B8_BodyMech_chk">Instruction in body mechanics lifting, bending and sitting (B8)</label>
             </div>
-            <input type="text" id="L_P6_B24_BodyMech_txt" name="L_P6_B24_BodyMech_txt" class="form-control form-control-sm mt-1" placeholder="B24 details...">
+            <input type="text" id="L_P6_B24_BodyMech_txt" name="L_P6_B24_BodyMech_txt" class="form-control form-control-sm mt-1" placeholder="B24 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P6_B9_GaitTraining_chk" name="L_P6_B9_GaitTraining_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B9_GaitTraining_chk">Gait training when muscle Control allows to stabilize pelvis (B9)</label>
             </div>
-            <input type="text" id="L_P6_B25_GaitTraining_txt" name="L_P6_B25_GaitTraining_txt" class="form-control form-control-sm mt-1" placeholder="B25 details...">
+            <input type="text" id="L_P6_B25_GaitTraining_txt" name="L_P6_B25_GaitTraining_txt" class="form-control form-control-sm mt-1" placeholder="B25 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P6_B10_MoldedInsoles_chk" name="L_P6_B10_MoldedInsoles_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B10_MoldedInsoles_chk">Molded Insoles to control foot function (B10)</label>
             </div>
-            <input type="text" id="L_P6_B26_MoldedInsoles_txt" name="L_P6_B26_MoldedInsoles_txt" class="form-control form-control-sm mt-1" placeholder="B26 details...">
+            <input type="text" id="L_P6_B26_MoldedInsoles_txt" name="L_P6_B26_MoldedInsoles_txt" class="form-control form-control-sm mt-1" placeholder="B26 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P6_B11_CustomOrthotics_chk" name="L_P6_B11_CustomOrthotics_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B11_CustomOrthotics_chk">Custom orthotics to control foot function (B11)</label>
             </div>
-            <input type="text" id="L_P6_B27_CustomOrthotics_txt" name="L_P6_B27_CustomOrthotics_txt" class="form-control form-control-sm mt-1" placeholder="B27 details...">
+            <input type="text" id="L_P6_B27_CustomOrthotics_txt" name="L_P6_B27_CustomOrthotics_txt" class="form-control form-control-sm mt-1" placeholder="B27 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P6_B12_ExAerobic_chk" name="L_P6_B12_ExAerobic_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B12_ExAerobic_chk">Exercises to improve strength, aerobic capacity (B12)</label>
             </div>
-            <input type="text" id="L_P6_B28_ExAerobic_txt" name="L_P6_B28_ExAerobic_txt" class="form-control form-control-sm mt-1" placeholder="B28 details...">
+            <input type="text" id="L_P6_B28_ExAerobic_txt" name="L_P6_B28_ExAerobic_txt" class="form-control form-control-sm mt-1" placeholder="B28 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P6_B13_TriggerPointInj_chk" name="L_P6_B13_TriggerPointInj_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B13_TriggerPointInj_chk">Trigger Point Injection (B13)</label>
             </div>
-            <input type="text" id="L_P6_B29_TriggerPointInj_txt" name="L_P6_B29_TriggerPointInj_txt" class="form-control form-control-sm mt-1" placeholder="B29 details...">
+            <input type="text" id="L_P6_B29_TriggerPointInj_txt" name="L_P6_B29_TriggerPointInj_txt" class="form-control form-control-sm mt-1" placeholder="B29 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P6_B14_IntraArticularInj_chk" name="L_P6_B14_IntraArticularInj_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B14_IntraArticularInj_chk">Intra articular Joint Injection (B14)</label>
             </div>
-            <input type="text" id="L_P6_B30_IntraArticularInj_txt" name="L_P6_B30_IntraArticularInj_txt" class="form-control form-control-sm mt-1" placeholder="B30 details...">
+            <input type="text" id="L_P6_B30_IntraArticularInj_txt" name="L_P6_B30_IntraArticularInj_txt" class="form-control form-control-sm mt-1" placeholder="B30 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P6_B15_DryNeedling_chk" name="L_P6_B15_DryNeedling_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B15_DryNeedling_chk">Dry needling Procidure (B15)</label>
             </div>
-            <input type="text" id="L_P6_B31_DryNeedling_txt" name="L_P6_B31_DryNeedling_txt" class="form-control form-control-sm mt-1" placeholder="B31 details...">
+            <input type="text" id="L_P6_B31_DryNeedling_txt" name="L_P6_B31_DryNeedling_txt" class="form-control form-control-sm mt-1" placeholder="B31 details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="L_P6_B16_JointStrapping_chk" name="L_P6_B16_JointStrapping_chk" value="checked">
                 <label class="form-check-label" for="L_P6_B16_JointStrapping_chk">Joint Stropping (B16)</label>
             </div>
-            <input type="text" id="L_P6_B32_JointStrapping_txt" name="L_P6_B32_JointStrapping_txt" class="form-control form-control-sm mt-1" placeholder="B32 details...">
+            <input type="text" id="L_P6_B32_JointStrapping_txt" name="L_P6_B32_JointStrapping_txt" class="form-control form-control-sm mt-1" placeholder="B32 details..." disabled>
         </div>
     </fieldset>
 
@@ -808,6 +808,81 @@
       console.error('Error: initFormSubmissionHandler is not defined. Check if form_handler.js is loaded correctly.');
     }
   });
+</script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const formIds = ['cervicalAssessmentForm', 'lumbarAssessmentForm', 'thoracicAssessmentForm'];
+    formIds.forEach(formId => {
+        const form = document.getElementById(formId);
+        if (!form) return;
+
+        const checkboxes = form.querySelectorAll('input[type="checkbox"]');
+        checkboxes.forEach(function(checkbox) {
+            let associatedTextInput = null;
+            const parentWrapper = checkbox.closest('.mb-2'); // Common wrapper for a checkbox and its related text input
+
+            if (parentWrapper) {
+                // Attempt 1: Text input is a direct child of parentWrapper and not in a .form-check div
+                associatedTextInput = parentWrapper.querySelector('input[type="text"]:not(.form-check-input), textarea:not(.form-check-input)');
+
+                // Refinement: Ensure the found text input is not part of another checkbox's immediate .form-check parent,
+                // unless it's the one being sought. This is tricky.
+                // A simpler structural assumption: the text input is a sibling of the checkbox's .form-check div,
+                // both being children of parentWrapper.
+                const formCheckDiv = checkbox.closest('.form-check');
+                if (formCheckDiv && formCheckDiv.parentElement === parentWrapper) {
+                    let nextSibling = formCheckDiv.nextElementSibling;
+                    if (nextSibling && (nextSibling.matches('input[type="text"]') || nextSibling.matches('textarea'))) {
+                        associatedTextInput = nextSibling;
+                    } else {
+                        // If not an immediate sibling, it might be a bit further, but still within parentWrapper.
+                        // This will re-select if the above didn't find it.
+                         associatedTextInput = parentWrapper.querySelector('input[type="text"], textarea');
+                         // Verify it's not inside another form-check or something unexpected
+                         if (associatedTextInput && associatedTextInput.closest('.form-check') && associatedTextInput.closest('.form-check') !== formCheckDiv) {
+                            associatedTextInput = null; // It belongs to another checkbox construct
+                         } else if (associatedTextInput && associatedTextInput.parentElement !== parentWrapper && associatedTextInput.parentElement !== formCheckDiv.parentElement) {
+                            // If it's too nested or not a direct child as expected, ignore
+                            // This condition might be too strict depending on actual variations
+                         }
+                    }
+                }
+            }
+
+            // Fallback or primary for IDs like X_chk and X_txt
+            if (!associatedTextInput && checkbox.id && checkbox.id.includes('_chk')) {
+                const textInputId = checkbox.id.replace('_chk', '_txt');
+                const potentialTextInput = document.getElementById(textInputId);
+                if (potentialTextInput && (potentialTextInput.type === 'text' || potentialTextInput.type === 'textarea')) {
+                    associatedTextInput = potentialTextInput;
+                }
+            }
+
+            // Another fallback for thoracic.html like P2_B1 (checkbox) and P2_B5 (text)
+            // This requires a more specific mapping if IDs are not systematically related.
+            // For now, relying on structure or _chk/_txt convention.
+
+            if (associatedTextInput) {
+                // Ensure HTML already has 'disabled' for initial state on page load.
+                // JS will manage it from now on.
+                // associatedTextInput.disabled = !checkbox.checked; // Set initial state via JS too
+                // if (!checkbox.checked) {
+                //    associatedTextInput.value = '';
+                // }
+
+                checkbox.addEventListener('change', function() {
+                    associatedTextInput.disabled = !this.checked;
+                    if (!this.checked) {
+                        associatedTextInput.value = ''; // Clear value when unchecked
+                    } else {
+                        // Optional: focus the text input when checkbox is checked
+                        // associatedTextInput.focus();
+                    }
+                });
+            }
+        });
+    });
+});
 </script>
 </body>
 </html>

--- a/patient_evaluation_form/thoracic.html
+++ b/patient_evaluation_form/thoracic.html
@@ -307,14 +307,14 @@
                 <input class="form-check-input" type="checkbox" id="P2_B1" name="P2_B1" value="checked">
                 <label class="form-check-label" for="P2_B1">Normal mobility</label>
             </div>
-            <input type="text" id="P2_B5" name="P2_B5" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P2_B5" name="P2_B5" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P2_B2" name="P2_B2" value="checked">
                 <label class="form-check-label" for="P2_B2">Stiff throughout</label>
             </div>
-            <input type="text" id="P2_B6" name="P2_B6" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P2_B6" name="P2_B6" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
     </fieldset>
 
@@ -325,14 +325,14 @@
                 <input class="form-check-input" type="checkbox" id="P2_B3" name="P2_B3" value="checked">
                 <label class="form-check-label" for="P2_B3">Normal mobility</label>
             </div>
-            <input type="text" id="P2_B7" name="P2_B7" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P2_B7" name="P2_B7" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P2_B4" name="P2_B4" value="checked">
                 <label class="form-check-label" for="P2_B4">Stiff throughout</label>
             </div>
-            <input type="text" id="P2_B8" name="P2_B8" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P2_B8" name="P2_B8" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <label for="P2_B9" class="form-label">Restricted Rotation on:</label>
@@ -351,14 +351,14 @@
                 <input class="form-check-input" type="checkbox" id="P2_B11" name="P2_B11" value="checked">
                 <label class="form-check-label" for="P2_B11">Restricted Rotation on</label>
             </div>
-            <input type="text" id="P2_B13" name="P2_B13" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P2_B13" name="P2_B13" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P2_B12" name="P2_B12" value="checked">
                 <label class="form-check-label" for="P2_B12">Hypermobility noted on</label>
             </div>
-            <input type="text" id="P2_B14" name="P2_B14" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P2_B14" name="P2_B14" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
     </fieldset>
 
@@ -369,42 +369,42 @@
                 <input class="form-check-input" type="checkbox" id="P2_B15" name="P2_B15" value="checked">
                 <label class="form-check-label" for="P2_B15">Erector Spinea</label>
             </div>
-            <input type="text" id="P2_B21" name="P2_B21" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P2_B21" name="P2_B21" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P2_B16" name="P2_B16" value="checked">
                 <label class="form-check-label" for="P2_B16">Rhomboid</label>
             </div>
-            <input type="text" id="P2_B22" name="P2_B22" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P2_B22" name="P2_B22" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P2_B17" name="P2_B17" value="checked">
                 <label class="form-check-label" for="P2_B17">Mid Traps.</label>
             </div>
-            <input type="text" id="P2_B23" name="P2_B23" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P2_B23" name="P2_B23" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P2_B18_palpation" name="P2_B18_palpation" value="checked">
                 <label class="form-check-label" for="P2_B18_palpation">Inter-Costal Muscle</label>
             </div>
-            <input type="text" id="P2_B24_palpation_text" name="P2_B24_palpation_text" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P2_B24_palpation_text" name="P2_B24_palpation_text" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P2_B19_palpation" name="P2_B19_palpation" value="checked">
                 <label class="form-check-label" for="P2_B19_palpation">Upper Traps.</label>
             </div>
-            <input type="text" id="P2_B25_palpation_text" name="P2_B25_palpation_text" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P2_B25_palpation_text" name="P2_B25_palpation_text" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P2_B20_palpation" name="P2_B20_palpation" value="checked">
                 <label class="form-check-label" for="P2_B20_palpation">Inter. Sp</label>
             </div>
-            <input type="text" id="P2_B26_palpation_text" name="P2_B26_palpation_text" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P2_B26_palpation_text" name="P2_B26_palpation_text" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <label for="P2_B27_palpation_remark" class="form-label">Remark (Palpation):</label>
@@ -419,105 +419,105 @@
                 <input class="form-check-input" type="checkbox" id="P3_B1" name="P3_B1" value="checked">
                 <label class="form-check-label" for="P3_B1">Postural Imbalance</label>
             </div>
-            <input type="text" id="P3_B16" name="P3_B16" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P3_B16" name="P3_B16" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P3_B2" name="P3_B2" value="checked">
                 <label class="form-check-label" for="P3_B2">Decreased AROM</label>
             </div>
-            <input type="text" id="P3_B17" name="P3_B17" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P3_B17" name="P3_B17" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P3_B3" name="P3_B3" value="checked">
                 <label class="form-check-label" for="P3_B3">Decreased passive Inter-Vertebral motion</label>
             </div>
-            <input type="text" id="P3_B18" name="P3_B18" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P3_B18" name="P3_B18" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P3_B4" name="P3_B4" value="checked">
                 <label class="form-check-label" for="P3_B4">Decreased strength</label>
             </div>
-            <input type="text" id="P3_B19" name="P3_B19" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P3_B19" name="P3_B19" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P3_B5" name="P3_B5" value="checked">
                 <label class="form-check-label" for="P3_B5">Hypertonic upper Quadrant Musculature</label>
             </div>
-            <input type="text" id="P3_B20" name="P3_B20" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P3_B20" name="P3_B20" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P3_B6" name="P3_B6" value="checked">
                 <label class="form-check-label" for="P3_B6">Adaptive Shortening of Muscles</label>
             </div>
-            <input type="text" id="P3_B21" name="P3_B21" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P3_B21" name="P3_B21" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P3_B7" name="P3_B7" value="checked">
                 <label class="form-check-label" for="P3_B7">Adverse neural tension</label>
             </div>
-            <input type="text" id="P3_B22" name="P3_B22" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P3_B22" name="P3_B22" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P3_B8" name="P3_B8" value="checked">
                 <label class="form-check-label" for="P3_B8">Decreased facet Joint Mobility</label>
             </div>
-            <input type="text" id="P3_B23" name="P3_B23" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P3_B23" name="P3_B23" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P3_B9" name="P3_B9" value="checked">
                 <label class="form-check-label" for="P3_B9">Decreased Costo-Vertebral Mobility</label>
             </div>
-            <input type="text" id="P3_B24" name="P3_B24" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P3_B24" name="P3_B24" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P3_B10" name="P3_B10" value="checked">
                 <label class="form-check-label" for="P3_B10">Rib Dysfunction</label>
             </div>
-            <input type="text" id="P3_B25" name="P3_B25" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P3_B25" name="P3_B25" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P3_B11" name="P3_B11" value="checked">
                 <label class="form-check-label" for="P3_B11">Decreased Mobility of Spine</label>
             </div>
-            <input type="text" id="P3_B26" name="P3_B26" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P3_B26" name="P3_B26" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P3_B12" name="P3_B12" value="checked">
                 <label class="form-check-label" for="P3_B12">Sensitive thoracic and lumbar vertebra to P-a oscilation</label>
             </div>
-            <input type="text" id="P3_B27" name="P3_B27" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P3_B27" name="P3_B27" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P3_B13" name="P3_B13" value="checked">
                 <label class="form-check-label" for="P3_B13">Rotoscoliosis</label>
             </div>
-            <input type="text" id="P3_B28" name="P3_B28" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P3_B28" name="P3_B28" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P3_B14" name="P3_B14" value="checked">
                 <label class="form-check-label" for="P3_B14">Scapulothoracic Dysfunction</label>
             </div>
-            <input type="text" id="P3_B29" name="P3_B29" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P3_B29" name="P3_B29" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P3_B15" name="P3_B15" value="checked">
                 <label class="form-check-label" for="P3_B15">Sterno-costal dysfunction</label>
             </div>
-            <input type="text" id="P3_B30" name="P3_B30" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P3_B30" name="P3_B30" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <label for="P3_B31_clinical_remark" class="form-label">Remark (Clinical Impression):</label>
@@ -536,133 +536,133 @@
                 <input class="form-check-input" type="checkbox" id="P4_B1" name="P4_B1" value="checked">
                 <label class="form-check-label" for="P4_B1">Modalities as Indicated</label>
             </div>
-            <input type="text" id="P4_B20" name="P4_B20" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B20" name="P4_B20" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B2" name="P4_B2" value="checked">
                 <label class="form-check-label" for="P4_B2">Postural Education and awareness training</label>
             </div>
-            <input type="text" id="P4_B21" name="P4_B21" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B21" name="P4_B21" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B3" name="P4_B3" value="checked">
                 <label class="form-check-label" for="P4_B3">Inhibition tecniques to reduce hyper-tonicity</label>
             </div>
-            <input type="text" id="P4_B22" name="P4_B22" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B22" name="P4_B22" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B4" name="P4_B4" value="checked">
                 <label class="form-check-label" for="P4_B4">Graded Streaching of Involved Muscles</label>
             </div>
-            <input type="text" id="P4_B23" name="P4_B23" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B23" name="P4_B23" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B5" name="P4_B5" value="checked">
                 <label class="form-check-label" for="P4_B5">ROM exercise for Cervical/thoracic spine</label>
             </div>
-            <input type="text" id="P4_B24" name="P4_B24" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B24" name="P4_B24" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B6" name="P4_B6" value="checked">
                 <label class="form-check-label" for="P4_B6">Manual or Mechanical traction</label>
             </div>
-            <input type="text" id="P4_B25" name="P4_B25" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B25" name="P4_B25" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B7" name="P4_B7" value="checked">
                 <label class="form-check-label" for="P4_B7">Soft tissue Mobilization</label>
             </div>
-            <input type="text" id="P4_B26" name="P4_B26" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B26" name="P4_B26" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B8" name="P4_B8" value="checked">
                 <label class="form-check-label" for="P4_B8">Joint Mobilization</label>
             </div>
-            <input type="text" id="P4_B27" name="P4_B27" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B27" name="P4_B27" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B9" name="P4_B9" value="checked">
                 <label class="form-check-label" for="P4_B9">Cervical Stabilization traning</label>
             </div>
-            <input type="text" id="P4_B28" name="P4_B28" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B28" name="P4_B28" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B10" name="P4_B10" value="checked">
                 <label class="form-check-label" for="P4_B10">Neural Mobilization</label>
             </div>
-            <input type="text" id="P4_B29" name="P4_B29" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B29" name="P4_B29" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B11" name="P4_B11" value="checked">
                 <label class="form-check-label" for="P4_B11">Upper Extrimity strengethening</label>
             </div>
-            <input type="text" id="P4_B30" name="P4_B30" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B30" name="P4_B30" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B12" name="P4_B12" value="checked">
                 <label class="form-check-label" for="P4_B12">Thoracic Strengethening</label>
             </div>
-            <input type="text" id="P4_B31" name="P4_B31" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B31" name="P4_B31" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B13" name="P4_B13" value="checked">
                 <label class="form-check-label" for="P4_B13">General Cardio/pulomonary Conditioning</label>
             </div>
-            <input type="text" id="P4_B32" name="P4_B32" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B32" name="P4_B32" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B14" name="P4_B14" value="checked">
                 <label class="form-check-label" for="P4_B14">Instruction in home Exercise program</label>
             </div>
-            <input type="text" id="P4_B33" name="P4_B33" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B33" name="P4_B33" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B15" name="P4_B15" value="checked">
                 <label class="form-check-label" for="P4_B15">Imaging studies</label>
             </div>
-            <input type="text" id="P4_B34" name="P4_B34" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B34" name="P4_B34" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B16" name="P4_B16" value="checked">
                 <label class="form-check-label" for="P4_B16">Trigger point Injection</label>
             </div>
-            <input type="text" id="P4_B35" name="P4_B35" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B35" name="P4_B35" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B17" name="P4_B17" value="checked">
                 <label class="form-check-label" for="P4_B17">Intra-articular Joint Injection</label>
             </div>
-            <input type="text" id="P4_B36" name="P4_B36" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B36" name="P4_B36" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B18_recommendation_dry_needling" name="P4_B18_recommendation_dry_needling" value="checked">
                 <label class="form-check-label" for="P4_B18_recommendation_dry_needling">Dry-needling procidure</label>
             </div>
-            <input type="text" id="P4_B37" name="P4_B37" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B37" name="P4_B37" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="P4_B19_recommendation_stropping" name="P4_B19_recommendation_stropping" value="checked">
                 <label class="form-check-label" for="P4_B19_recommendation_stropping">Joint Stropping</label>
             </div>
-            <input type="text" id="P4_B38" name="P4_B38" class="form-control form-control-sm mt-1" placeholder="Details...">
+            <input type="text" id="P4_B38" name="P4_B38" class="form-control form-control-sm mt-1" placeholder="Details..." disabled>
         </div>
         <div class="mb-2">
             <label for="P4_B39_recommendation_remark" class="form-label">Remark (Recommendation):</label>
@@ -718,6 +718,81 @@
       console.error('Error: initFormSubmissionHandler is not defined. Check if form_handler.js is loaded correctly.');
     }
   });
+</script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const formIds = ['cervicalAssessmentForm', 'lumbarAssessmentForm', 'thoracicAssessmentForm'];
+    formIds.forEach(formId => {
+        const form = document.getElementById(formId);
+        if (!form) return;
+
+        const checkboxes = form.querySelectorAll('input[type="checkbox"]');
+        checkboxes.forEach(function(checkbox) {
+            let associatedTextInput = null;
+            const parentWrapper = checkbox.closest('.mb-2'); // Common wrapper for a checkbox and its related text input
+
+            if (parentWrapper) {
+                // Attempt 1: Text input is a direct child of parentWrapper and not in a .form-check div
+                associatedTextInput = parentWrapper.querySelector('input[type="text"]:not(.form-check-input), textarea:not(.form-check-input)');
+
+                // Refinement: Ensure the found text input is not part of another checkbox's immediate .form-check parent,
+                // unless it's the one being sought. This is tricky.
+                // A simpler structural assumption: the text input is a sibling of the checkbox's .form-check div,
+                // both being children of parentWrapper.
+                const formCheckDiv = checkbox.closest('.form-check');
+                if (formCheckDiv && formCheckDiv.parentElement === parentWrapper) {
+                    let nextSibling = formCheckDiv.nextElementSibling;
+                    if (nextSibling && (nextSibling.matches('input[type="text"]') || nextSibling.matches('textarea'))) {
+                        associatedTextInput = nextSibling;
+                    } else {
+                        // If not an immediate sibling, it might be a bit further, but still within parentWrapper.
+                        // This will re-select if the above didn't find it.
+                         associatedTextInput = parentWrapper.querySelector('input[type="text"], textarea');
+                         // Verify it's not inside another form-check or something unexpected
+                         if (associatedTextInput && associatedTextInput.closest('.form-check') && associatedTextInput.closest('.form-check') !== formCheckDiv) {
+                            associatedTextInput = null; // It belongs to another checkbox construct
+                         } else if (associatedTextInput && associatedTextInput.parentElement !== parentWrapper && associatedTextInput.parentElement !== formCheckDiv.parentElement) {
+                            // If it's too nested or not a direct child as expected, ignore
+                            // This condition might be too strict depending on actual variations
+                         }
+                    }
+                }
+            }
+
+            // Fallback or primary for IDs like X_chk and X_txt
+            if (!associatedTextInput && checkbox.id && checkbox.id.includes('_chk')) {
+                const textInputId = checkbox.id.replace('_chk', '_txt');
+                const potentialTextInput = document.getElementById(textInputId);
+                if (potentialTextInput && (potentialTextInput.type === 'text' || potentialTextInput.type === 'textarea')) {
+                    associatedTextInput = potentialTextInput;
+                }
+            }
+
+            // Another fallback for thoracic.html like P2_B1 (checkbox) and P2_B5 (text)
+            // This requires a more specific mapping if IDs are not systematically related.
+            // For now, relying on structure or _chk/_txt convention.
+
+            if (associatedTextInput) {
+                // Ensure HTML already has 'disabled' for initial state on page load.
+                // JS will manage it from now on.
+                // associatedTextInput.disabled = !checkbox.checked; // Set initial state via JS too
+                // if (!checkbox.checked) {
+                //    associatedTextInput.value = '';
+                // }
+
+                checkbox.addEventListener('change', function() {
+                    associatedTextInput.disabled = !this.checked;
+                    if (!this.checked) {
+                        associatedTextInput.value = ''; // Clear value when unchecked
+                    } else {
+                        // Optional: focus the text input when checkbox is checked
+                        // associatedTextInput.focus();
+                    }
+                });
+            }
+        });
+    });
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
…heckboxes:

```
Feat: Implement conditional text inputs for checkboxes

This commit introduces two main changes to the HTML forms in
`patient_evaluation_form/` (specifically cervical.html, lumbar.html,
and thoracic.html):

1.  **Default Disabled Text Inputs:** Text input fields that are
    semantically associated with a preceding checkbox (e.g., for
    providing details or remarks for a checked option) are now
    set to `disabled` by default in the HTML.

2.  **JavaScript for Conditional Logic:** Added inline JavaScript to
    these forms (`cervical.html`, `lumbar.html`, `thoracic.html`).
    This script:
    - Identifies checkboxes and their associated text inputs.
    - Attaches event listeners to the checkboxes.
    - When a checkbox is checked, its associated text input is enabled.
    - When a checkbox is unchecked, its associated text input is
      disabled and its value is cleared.

This enhances your experience by ensuring that detail fields are only
active when relevant and that all checkboxes default to an unchecked state
(verified as existing behavior).
```