### PR TITLE
Fix: Correctly display 'checked' values in submission view

### DIFF
--- a/pages/view_submission_detail.php
+++ b/pages/view_submission_detail.php
@@ -144,7 +144,7 @@ include_once $path_to_root . 'includes/header.php';
                             // Define falsey and truthy values (lowercase for case-insensitive comparison)
                             $falseyValues = ["0", "false", "no", "off"];
                             // Empty string is handled separately to mean "don't display row"
-                            $truthyValues = ["1", "true", "yes", "on"];
+                            $truthyValues = ["1", "true", "yes", "on", "checked"];
 
                             if ($trimmedValue === '') {
                                  $shouldDisplayRow = false; // Don't display row for empty strings


### PR DESCRIPTION
I modified `pages/view_submission_detail.php` to include the literal string "checked" in its array of truthy values.

Previously, if a form field was submitted with the value "checked" (as is the case for standard checkboxes in this application), the view script would display the literal string "checked" rather than recognizing it as an affirmative boolean state.

This change ensures that such fields are now displayed with the generic "Checked" indicator (e.g., <em>Checked</em>), aligning the display logic with how other truthy values like "true" or "on" were handled. This is intended to fix an issue where you might see the raw "checked" string for selected checkboxes instead of a more user-friendly confirmation.