### PR TITLE
Fix: Select assigned_clinician_id in patient search query

### DIFF
--- a/pages/assign_existing_patient.php
+++ b/pages/assign_existing_patient.php
@@ -61,7 +61,7 @@ if ($_SERVER["REQUEST_METHOD"] == "GET" && isset($_GET['search_term'])) {
 
             // Reverting to a slightly modified version of the original for less disruptive change first.
             // Ensure parameter names are distinct if they were to hold different values.
-            $sql_search = "SELECT patients.id, patients.first_name, patients.last_name, patients.date_of_birth,
+            $sql_search = "SELECT patients.id, patients.first_name, patients.last_name, patients.date_of_birth, patients.assigned_clinician_id,
                                   u_assigned.first_name as assigned_fn, u_assigned.last_name as assigned_ln,
                                   u_assigned.username as assigned_username
                            FROM patients


### PR DESCRIPTION
- Modified `pages/assign_existing_patient.php` to include `patients.assigned_clinician_id` in the SELECT list of the patient search query.
- This resolves an "Undefined array key 'assigned_clinician_id'" error that occurred when displaying search results and attempting to determine the patient's current assigned clinician for the UI.

This commit also includes previous enhancements for patient workflow, role-specific features, and other fixes.