### PR TITLE
Refactor: Update nurse vital signs workflow

### DIFF
--- a/pages/fill_patient_form.php
+++ b/pages/fill_patient_form.php
@@ -15,6 +15,27 @@ if (!isset($_SESSION['user_id']) || !in_array($_SESSION['role'], ['clinician', '
 $select_patient_page = ($_SESSION['role'] === 'nurse') ? 'nurse_select_patient.php' : 'select_patient_for_form.php';
 $select_form_page = ($_SESSION['role'] === 'nurse') ? 'nurse_select_form.php' : 'select_form_for_patient.php';
 
+// Check if a patient_id is provided in the URL and update/set the session
+// This allows direct linking to this page with a patient context.
+if (isset($_GET['patient_id']) && !empty(trim($_GET['patient_id']))) {
+    $patient_id_from_get = trim($_GET['patient_id']);
+    // Basic validation: ensure it's a positive integer. Adjust if patient IDs have a different format.
+    if (filter_var($patient_id_from_get, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]])) {
+        $_SESSION['selected_patient_id_for_form'] = $patient_id_from_get;
+    } else {
+        // Optional: Log this attempt or handle more gracefully.
+        // For now, if an invalid patient_id is passed, it might be better to clear any existing
+        // selected_patient_id_for_form to force re-selection, or redirect with an error.
+        // For simplicity here, we'll let it fall through to the session check below,
+        // which would fail if the GET patient_id was invalid and no valid one was in session.
+        // A more robust handling might be:
+        // $_SESSION['message'] = "Invalid patient ID format provided in URL.";
+        // header("Location: " . $select_patient_page);
+        // exit();
+        // However, if a valid ID is already in session, we might want to use that.
+        // The current approach is to override session if a valid patient_id is in GET.
+    }
+}
 
 // 2. Retrieve form_name and form_directory from URL
 if (!isset($_GET['form_name']) || empty(trim($_GET['form_name']))) {

--- a/pages/nurse_select_patient.php
+++ b/pages/nurse_select_patient.php
@@ -66,7 +66,7 @@ try {
                         <td><?php echo htmlspecialchars($patient['last_name']); ?></td>
                         <td><?php echo htmlspecialchars($patient['date_of_birth']); ?></td>
                         <td>
-                            <a href="fill_patient_form.php?patient_id=<?php echo htmlspecialchars($patient['id']); ?>&form_name=vital_signs.html&form_directory=patient_general_info" class="btn btn-primary btn-sm">Enter Vitals</a>
+                            <a href="fill_patient_form.php?patient_id=<?php echo htmlspecialchars($patient['id']); ?>&form_name=general-information.html&form_directory=patient_general_info" class="btn btn-primary btn-sm">Enter Vitals</a>
                         </td>
                     </tr>
                 <?php endforeach; ?>


### PR DESCRIPTION
- Modify 'Enter Vitals' link on the nurse patient selection page to point to the 'general-information.html' form instead of the standalone 'vital_signs.html'.
- Update 'fill_patient_form.php' to correctly use 'patient_id' from GET parameters to set the selected patient in the session.

This change ensures that when a nurse clicks to add/enter vitals, they are directed to the comprehensive general information form, which includes a section for vitals, fulfilling the requirement to go to the general info page.