### PR TITLE
fix: Correct parameter binding in patient search for invoicing

### DIFF
--- a/pages/receptionist_view_patient_billing.php
+++ b/pages/receptionist_view_patient_billing.php
@@ -18,9 +18,13 @@ $selected_patient_id = filter_input(INPUT_GET, 'patient_id', FILTER_VALIDATE_INT
 
 if ($searchTerm) {
     $stmt_patients_search = $db->prepare("SELECT id, first_name, last_name, date_of_birth FROM patients
-                                          WHERE first_name LIKE :term OR last_name LIKE :term OR id LIKE :term_id
+                                          WHERE first_name LIKE :term_fn OR last_name LIKE :term_ln OR id LIKE :term_id_like
                                           ORDER BY last_name, first_name LIMIT 20");
-    $db->execute($stmt_patients_search, [':term' => "%" . $searchTerm . "%", ':term_id' => $searchTerm]);
+    $db->execute($stmt_patients_search, [
+        ':term_fn' => "%" . $searchTerm . "%",
+        ':term_ln' => "%" . $searchTerm . "%",
+        ':term_id_like' => "%" . $searchTerm . "%"
+    ]);
     $searched_patients_list = $db->fetchAll($stmt_patients_search);
 } else if (!$selected_patient_id) {
     // Optionally, load all patients if no search and no selection, for a dropdown.


### PR DESCRIPTION
Changed the patient search query in
`pages/receptionist_view_patient_billing.php` to use distinct named placeholders for each LIKE clause. This is to resolve a potential "SQLSTATE[HY093]: Invalid parameter number" error.