### PR TITLE
refactor: Introduce payments table and update invoices schema

### DIFF
--- a/physio_db_schema.sql
+++ b/physio_db_schema.sql
@@ -128,13 +128,11 @@ CREATE TABLE IF NOT EXISTS invoices (
     patient_id INT NOT NULL,
     invoice_number VARCHAR(50) NOT NULL UNIQUE,
     invoice_date DATE NOT NULL,
-    due_date DATE NULL, -- Corrected
+    due_date DATE NULL,
     total_amount DECIMAL(10, 2) NOT NULL,
-    amount_paid DECIMAL(10, 2) NOT NULL DEFAULT 0.00,
+    amount_paid DECIMAL(10, 2) NOT NULL DEFAULT 0.00, -- This will be sum of payments
     payment_status ENUM('unpaid', 'paid', 'partially_paid', 'void') NOT NULL DEFAULT 'unpaid',
-    payment_date DATETIME NULL, -- Corrected
-    payment_method VARCHAR(50) NULL, -- Corrected
-    payment_notes TEXT NULL, -- Corrected
+    -- payment_date, payment_method, payment_notes removed, moved to 'payments' table
     created_by_user_id INT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -156,4 +154,21 @@ CREATE TABLE IF NOT EXISTS invoice_items (
     INDEX idx_invoiceitems_patient_procedure_id (patient_procedure_id),
     CONSTRAINT fk_invoiceitems_invoice FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE CASCADE,
     CONSTRAINT fk_invoiceitems_patient_procedure FOREIGN KEY (patient_procedure_id) REFERENCES patient_procedures(id) ON DELETE RESTRICT
+) ENGINE=InnoDB;
+
+-- Payments Table
+CREATE TABLE IF NOT EXISTS payments (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    invoice_id INT NOT NULL,
+    payment_date DATETIME NOT NULL,
+    amount_paid DECIMAL(10, 2) NOT NULL,
+    payment_method VARCHAR(50) NOT NULL,
+    manual_receipt_number VARCHAR(50) NULLABLE,
+    payment_notes TEXT NULLABLE,
+    recorded_by_user_id INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_payments_invoice_id (invoice_id),
+    INDEX idx_payments_payment_date (payment_date),
+    CONSTRAINT fk_payments_invoice FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE CASCADE,
+    CONSTRAINT fk_payments_recorded_by FOREIGN KEY (recorded_by_user_id) REFERENCES users(id) ON DELETE RESTRICT
 ) ENGINE=InnoDB;


### PR DESCRIPTION
Phase 1, Step 1 (Invoice System v2) complete:
- Created the `payments` table to store individual payment transactions, including details like payment_method, manual_receipt_number, and notes.
- Modified the `invoices` table to remove direct payment detail columns (payment_date, payment_method, payment_notes), as these will now be tracked in the `payments` table. The `invoices.amount_paid` column will be updated by summing related payments.
- Updated `includes/setup_invoicing_tables.php` with DDL for these changes, including logic to drop the old columns from `invoices`.
- Updated `physio_db_schema.sql` to reflect the new schema.