### PR TITLE
debug: Add CSRF token debugging to procedure management

### DIFF
--- a/pages/admin_manage_procedures.php
+++ b/pages/admin_manage_procedures.php
@@ -17,6 +17,17 @@ $procedures = $db->fetchAll($stmt_procedures);
 $old_input = SessionManager::get('form_old_input', []);
 SessionManager::remove('form_old_input');
 
+// --- DEBUG START for CSRF ---
+echo "<pre style='background-color: #f0f0f0; border: 1px solid #ccc; padding: 10px; margin: 10px; white-space: pre-wrap;'><strong>DEBUG (admin_manage_procedures.php)</strong>\n";
+echo "SESSION before token generation:\n";
+var_dump($_SESSION);
+$generated_csrf_token_for_form = SessionManager::generateCsrfToken(); // Generate and store
+echo "SESSION after token generation:\n";
+var_dump($_SESSION);
+echo "Generated CSRF Token for form: " . htmlspecialchars($generated_csrf_token_for_form);
+echo "</pre>";
+// --- DEBUG END for CSRF ---
+
 // Include header
 require_once $path_to_root . 'includes/header.php';
 ?>
@@ -40,7 +51,7 @@ require_once $path_to_root . 'includes/header.php';
         </div>
         <div class="card-body">
             <form action="<?php echo $path_to_root; ?>php/handle_add_procedure.php" method="POST">
-                <input type="hidden" name="csrf_token" value="<?php echo SessionManager::generateCsrfToken(); ?>">
+                <input type="hidden" name="csrf_token" value="<?php echo $generated_csrf_token_for_form; ?>">
                 <div class="row">
                     <div class="col-md-6 mb-3">
                         <label for="name" class="form-label">Procedure Name</label>

--- a/php/handle_add_procedure.php
+++ b/php/handle_add_procedure.php
@@ -11,6 +11,17 @@ ErrorHandler::register();
 require_once $path_to_root . 'includes/db_connect.php'; // Provides $pdo
 require_once $path_to_root . 'includes/Database.php';    // Provides Database class
 
+// --- DEBUG START for CSRF ---
+echo "<pre style='background-color: #f0f0f0; border: 1px solid #ccc; padding: 10px; margin: 10px; white-space: pre-wrap;'><strong>DEBUG (handle_add_procedure.php)</strong>\n";
+echo "SESSION at start of handler:\n";
+var_dump($_SESSION);
+echo "POST data:\n";
+var_dump($_POST);
+$submittedToken_debug = isset($_POST['csrf_token']) ? $_POST['csrf_token'] : 'NOT SET IN POST';
+echo "Submitted CSRF Token (from POST): " . htmlspecialchars($submittedToken_debug);
+echo "</pre>";
+// --- DEBUG END for CSRF ---
+
 // CSRF Token Validation
 $submittedToken = isset($_POST['csrf_token']) ? $_POST['csrf_token'] : '';
 if (!SessionManager::validateCsrfToken($submittedToken)) {


### PR DESCRIPTION
Added var_dumps and echos to `pages/admin_manage_procedures.php` and `php/handle_add_procedure.php` to inspect session state and CSRF token values at generation, in form, and at validation. This is to diagnose an unexpected "Invalid or missing CSRF token" error.

These debug statements should be removed once the issue is resolved.