### PR TITLE
Fix: Resolve HY093 error in Active Patients report

### DIFF
--- a/pages/admin_reports.php
+++ b/pages/admin_reports.php
@@ -210,16 +210,21 @@ if (isset($_GET['report_name']) && $_GET['report_name'] === 'total_collected') {
                         AND EXISTS (
                             SELECT 1 FROM patient_procedures pp
                             WHERE pp.patient_id = pat.id
-                            AND pp.date_performed >= :start_date AND pp.date_performed <= :end_date
+                            AND pp.date_performed >= :pp_start_date AND pp.date_performed <= :pp_end_date
                             UNION ALL
                             SELECT 1 FROM patient_form_submissions pfs
                             WHERE pfs.patient_id = pat.id
-                            AND pfs.submission_timestamp >= :start_date AND pfs.submission_timestamp <= :end_date
+                            AND pfs.submission_timestamp >= :pfs_start_date AND pfs.submission_timestamp <= :pfs_end_date
                         )
                         ORDER BY pat.last_name, pat.first_name";
 
                 $stmt = $db->prepare($sql);
-                $db->execute($stmt, [':start_date' => $start_date, ':end_date' => $end_date]);
+                $db->execute($stmt, [
+                    ':pp_start_date' => $start_date,
+                    ':pp_end_date' => $end_date,
+                    ':pfs_start_date' => $start_date,
+                    ':pfs_end_date' => $end_date
+                ]);
                 $active_patients_list = $db->fetchAll($stmt);
                 $active_patients_count = count($active_patients_list);
 


### PR DESCRIPTION
Corrected an 'SQLSTATE[HY093]: Invalid parameter number' error in the 'Active Patients by Clinician Assignment & Activity' report within `pages/admin_reports.php`.

The error was caused by reusing the named placeholders `:start_date` and `:end_date` across different subqueries within an `EXISTS` clause (specifically in a `UNION ALL`).

Changed the placeholders to be unique for each subquery (e.g., `:pp_start_date`, `:pp_end_date`, `:pfs_start_date`, `:pfs_end_date`) and updated the `execute()` call to bind values to these unique placeholders accordingly. This resolves the parameter mismatch error.